### PR TITLE
Icon fuer Pdf aktualisiert

### DIFF
--- a/frontend/src/components/zaehlstelle/ZaehldatenDiagramme.vue
+++ b/frontend/src/components/zaehlstelle/ZaehldatenDiagramme.vue
@@ -195,7 +195,7 @@
                         @click="generatePdf"
                         v-on="on"
                     >
-                        <v-icon>mdi-file-pdf</v-icon>
+                        <v-icon>mdi-file-pdf-box</v-icon>
                     </v-btn>
                 </template>
                 <span>PDF</span>


### PR DESCRIPTION
**Description**
 In der Listenausgabe war das Icon für den PDF-Export nicht sichtbar. Dies wurde hiermit korrigiert.