### PR TITLE
variable von globale zu block-scope geändert

### DIFF
--- a/frontend/src/util/DateUtils.ts
+++ b/frontend/src/util/DateUtils.ts
@@ -2,8 +2,6 @@ import { useI18n } from "vue-i18n-composable";
 import { useSnackbarStore } from "@/store/snackbar";
 
 export function useDateUtils() {
-    const i18n = useI18n();
-
     const snackbarStore = useSnackbarStore();
 
     function formatDate(date: string): string {
@@ -15,6 +13,7 @@ export function useDateUtils() {
     }
 
     function getTimeOfDate(date: Date): string {
+        const i18n = useI18n();
         if (!date) {
             return "";
         }
@@ -22,6 +21,7 @@ export function useDateUtils() {
     }
 
     function getShortVersionOfDate(date: Date): string {
+        const i18n = useI18n();
         if (!date) {
             return "";
         }
@@ -29,6 +29,7 @@ export function useDateUtils() {
     }
 
     function getLongVersionOfDate(date: Date): string {
+        const i18n = useI18n();
         if (!date) {
             return "";
         }


### PR DESCRIPTION
**Description**

- variable von global auf block scope geändert, damit die aktuellen tests funktionieren.
- muss vorraussichtlich nochmal umgebaut werden, sobald vue3 im einsatz ist, da dafür neue änderungen gibt und es aktuell auf einer nichtmehr gepflegeten dependency basiert. 

**Reference**

Issues #XXX
