### PR TITLE
DAVE-418 BUG Austausch Custom Date Picker durch vue3datepicker

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@fontsource/roboto": "^4.5.8",
         "@mdi/font": "7.3.67",
+        "@vuepic/vue-datepicker": "^10.0.0",
         "moment": "^2.29.4",
         "pinia": "^2.1.7",
         "sass": "^1.77.6",
@@ -1957,6 +1958,20 @@
         "vue-component-type-helpers": "^2.0.0"
       }
     },
+    "node_modules/@vuepic/vue-datepicker": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@vuepic/vue-datepicker/-/vue-datepicker-10.0.0.tgz",
+      "integrity": "sha512-ujlk3ahftVQpyCJ8hq7TmOOHrf/XFJI1ZcAh/FRB5Ci62Vq5HmHf6xux5KVi5SPUFRTJY78m+uDhYy1M+8RZ9w==",
+      "dependencies": {
+        "date-fns": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "vue": ">=3.2.0"
+      }
+    },
     "node_modules/@vuetify/loader-shared": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@vuetify/loader-shared/-/loader-shared-1.7.1.tgz",
@@ -2567,6 +2582,15 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/de-indent": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@fontsource/roboto": "^4.5.8",
     "@mdi/font": "7.3.67",
+    "@vuepic/vue-datepicker": "^10.0.0",
     "moment": "^2.29.4",
     "pinia": "^2.1.7",
     "sass": "^1.77.6",

--- a/frontend/src/components/common/DatePicker.vue
+++ b/frontend/src/components/common/DatePicker.vue
@@ -1,17 +1,27 @@
 <template>
-  <vue-date-picker
-      v-model="date"
-      placeholder="Datum eingeben ..."
-      :text-input="TEXT_INPUT_OPTIONS"
-      :format="format"
-      :enable-time-picker="false"
-  />
+  <v-row class="mb-1">
+    <v-col cols="12">
+      <!-- https://vue3datepicker.com/ -->
+      <vue-date-picker
+          v-model="date"
+          placeholder="Datum eingeben ..."
+          :config="GENERAL_DATE_PICKER_CONFIG"
+          :text-input="TEXT_INPUT_OPTIONS"
+          :locale="'de-DE'"
+          :format="format"
+          :enable-time-picker="false"
+          :disabled="props.disabled"
+          :required="props.required"
+          :select-text="'Übernehmen'"
+          :cancel-text="'Abbrechen'"
+      />
+    </v-col>
+  </v-row>
 </template>
 
 <script setup lang="ts">
-import VueDatePicker from '@vuepic/vue-datepicker';
+import VueDatePicker, {type GeneralConfig} from '@vuepic/vue-datepicker';
 import '@vuepic/vue-datepicker/dist/main.css';
-import {useDateUtils} from "@/util/DateUtils";
 
 interface Props {
   label?: string; // Bezeichnung des Datumsfelds
@@ -21,40 +31,33 @@ interface Props {
   maxDate: string; // Ob das Datumsfeld deaktiviert sein soll
 }
 
-const dateUtils = useDateUtils();
-
-interface Emits {
-  (event: "blur", value: Date | undefined): void;
-}
-
-const TEXT_INPUT_OPTIONS = {
-  format: 'dd.MM.yyyy',
-};
-const DISPLAY_FORMAT = "DD.MM.YYYY";
-
 const props = withDefaults(defineProps<Props>(), {
   label: "",
   required: false,
   disabled: false,
 });
-const emit = defineEmits<Emits>();
 const date = defineModel<Date | undefined>();
 
+// https://vue3datepicker.com/props/modes-configuration/#text-input-configuration
+const TEXT_INPUT_OPTIONS = {
+  enterSubmit: true,
+  tabSubmit: true,
+  openMenu: 'toggle',
+  format: 'dd.MM.yyyy',
+};
+
+// https://vue3datepicker.com/props/general-configuration/#config
+const GENERAL_DATE_PICKER_CONFIG = {
+  setDateOnMenuClose: true,
+}
+
+// https://vue3datepicker.com/props/formatting/#format
 const format = (date: Date) => {
-  const options = {
+  const options : Intl.DateTimeFormatOptions = {
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',
-  } as Intl.DateTimeFormatOptions;
+  };
   return date.toLocaleDateString('de-DE', options);
-};
-function validateTextDate(toCheck: string) {
-  return (
-      dateUtils.isDateBetweenAsStrings(
-          dateUtils.formatDateAsStringToISO(toCheck),
-          props.minDate,
-          props.maxDate
-      ) || "Das eingegebene Datum liegt außerhalb des gültigen Bereichs."
-  );
 };
 </script>

--- a/frontend/src/components/common/DatePicker.vue
+++ b/frontend/src/components/common/DatePicker.vue
@@ -72,6 +72,7 @@ const props = withDefaults(defineProps<Props>(), {
 });
 const emit = defineEmits<Emits>();
 const date = defineModel<Date | undefined>();
+const choosenDate = ref<string | undefined>(undefined);
 const datePickerActive = ref(false);
 const displayFormat = ref(DISPLAY_FORMAT);
 
@@ -79,7 +80,7 @@ const datePickerDate = computed({
   get() {
     if (!_.isNil(date.value)) {
       const parsedValue = moment.utc(date.value);
-      if (!parsedValue.isSame(0)) {
+      if (parsedValue.isValid() && !parsedValue.isSame(0)) {
         return moment(parsedValue.format(ISO_FORMAT)).toDate();
       }
     }

--- a/frontend/src/components/common/DatePicker.vue
+++ b/frontend/src/components/common/DatePicker.vue
@@ -72,7 +72,6 @@ const props = withDefaults(defineProps<Props>(), {
 });
 const emit = defineEmits<Emits>();
 const date = defineModel<Date | undefined>();
-const choosenDate = ref<string | undefined>(undefined);
 const datePickerActive = ref(false);
 const displayFormat = ref(DISPLAY_FORMAT);
 
@@ -91,9 +90,13 @@ const datePickerDate = computed({
   },
 
   set(value: Date) {
-    // Hack damit die Zeit korrekt umgerechnet wird.
-    value.setHours(5);
-    date.value = value;
+    const parsedValue = moment.utc(date.value);
+    if (parsedValue.isValid() && !parsedValue.isSame(0)) {
+      // Hack damit die Zeit korrekt umgerechnet wird.
+      value.setHours(5);
+      date.value = value;
+    }
+
   },
 });
 
@@ -101,7 +104,7 @@ const textFieldDate = computed({
   get() {
     if (!_.isNil(date.value)) {
       const parsedValue = moment.utc(date.value);
-      if (!parsedValue.isSame(0)) {
+      if (parsedValue.isValid() && !parsedValue.isSame(0)) {
         return parsedValue.local().format(displayFormat.value);
       }
     }
@@ -115,10 +118,8 @@ const textFieldDate = computed({
     /* Hier wird das Datum im "strict mode" geparsed, um den Nutzer-Input
     möglichst strikt zu validieren (https://momentjs.com/docs/#/parsing/is-valid/). */
     const parsedValue = moment.utc(value, displayFormat.value, true);
-    if (parsedValue.isValid()) {
+    if (parsedValue.isValid() && !parsedValue.isSame(0)) {
       date.value = parsedValue.toDate();
-    } else {
-      date.value = undefined;
     }
   },
 });

--- a/frontend/src/components/common/DatePicker.vue
+++ b/frontend/src/components/common/DatePicker.vue
@@ -8,7 +8,7 @@
         id="datum"
         v-model="textFieldDate"
         variant="underlined"
-        validate-on="input"
+        validate-on="blur"
         :hint="displayFormat"
         :disabled="disabled"
         :required="required"

--- a/frontend/src/components/common/DatePicker.vue
+++ b/frontend/src/components/common/DatePicker.vue
@@ -1,6 +1,11 @@
 <template>
-  <v-row class="mb-1">
-    <v-col cols="12">
+  <v-row class="pl-1 ma-0">
+    <v-field-label>
+      {{ props.label }}
+    </v-field-label>
+  </v-row>
+  <v-row class="mb-3">
+    <v-col class="my-0" cols="12">
       <!-- https://vue3datepicker.com/ -->
       <vue-date-picker
           v-model="date"
@@ -39,7 +44,7 @@ const props = withDefaults(defineProps<Props>(), {
 const date = defineModel<Date | undefined>();
 
 // https://vue3datepicker.com/props/modes-configuration/#text-input-configuration
-const TEXT_INPUT_OPTIONS = {
+const TEXT_INPUT_OPTIONS: any = {
   enterSubmit: true,
   tabSubmit: true,
   openMenu: 'toggle',
@@ -47,7 +52,7 @@ const TEXT_INPUT_OPTIONS = {
 };
 
 // https://vue3datepicker.com/props/general-configuration/#config
-const GENERAL_DATE_PICKER_CONFIG = {
+const GENERAL_DATE_PICKER_CONFIG: GeneralConfig = {
   setDateOnMenuClose: true,
 }
 

--- a/frontend/src/components/common/DatePicker.vue
+++ b/frontend/src/components/common/DatePicker.vue
@@ -12,6 +12,7 @@
     :enable-time-picker="true"
     :disabled="props.disabled"
     :required="props.required"
+    :clearable="false"
     auto-apply
   >
     <template
@@ -33,6 +34,7 @@
         :model-value="value"
         variant="underlined"
         :rules="[(toCheck: string) => validateTextDate(toCheck)]"
+        clearable
         @blur="onBlur"
         @input="onInput"
         @click:clear="onClear"

--- a/frontend/src/components/common/DatePicker.vue
+++ b/frontend/src/components/common/DatePicker.vue
@@ -1,10 +1,10 @@
 <template>
-  <v-row class="pl-1 ma-0">
+  <v-row class="pl-0 ma-0">
     <v-field-label>
       {{ props.label }}
     </v-field-label>
   </v-row>
-  <v-row class="mb-3">
+  <v-row :class="dateValidationMessage.length > 0 ? 'mb-0' : 'mb-3'">
     <v-col class="my-0" cols="12">
       <!-- https://vue3datepicker.com/ -->
       <vue-date-picker
@@ -22,11 +22,20 @@
       />
     </v-col>
   </v-row>
+  <div
+      v-if="dateValidationMessage.length > 0"
+      class="pl-2 pt-0 mt-0 mb-3 text-body-2">
+      {{ dateValidationMessage}}
+  </div>
 </template>
 
 <script setup lang="ts">
 import VueDatePicker, {type GeneralConfig} from '@vuepic/vue-datepicker';
 import '@vuepic/vue-datepicker/dist/main.css';
+import {useDateUtils} from "@/util/DateUtils";
+import {computed} from "vue";
+import _ from "lodash";
+import moment from "moment";
 
 interface Props {
   label?: string; // Bezeichnung des Datumsfelds
@@ -35,6 +44,12 @@ interface Props {
   minDate: string; // Ob das Datumsfeld deaktiviert sein soll
   maxDate: string; // Ob das Datumsfeld deaktiviert sein soll
 }
+
+const options : Intl.DateTimeFormatOptions = {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+};
 
 const props = withDefaults(defineProps<Props>(), {
   label: "",
@@ -58,11 +73,20 @@ const GENERAL_DATE_PICKER_CONFIG: GeneralConfig = {
 
 // https://vue3datepicker.com/props/formatting/#format
 const format = (date: Date) => {
-  const options : Intl.DateTimeFormatOptions = {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  };
   return date.toLocaleDateString('de-DE', options);
 };
+
+const dateValidationMessage = computed<string>(() => {
+  let validationMessage = "";
+  if (!_.isNil(date.value) && moment.utc(date.value).isValid()) {
+    const dateToCheck = date.value.toLocaleDateString('de-DE', options);
+    const isDateBetween = useDateUtils().isDateBetweenAsStrings(
+        useDateUtils().formatDateAsStringToISO(dateToCheck),
+        props.minDate,
+        props.maxDate
+    );
+    validationMessage = isDateBetween ? "" : "Das eingegebene Datum liegt außerhalb des gültigen Bereichs.";
+  }
+  return validationMessage;
+})
 </script>

--- a/frontend/src/components/common/DateRangePicker.vue
+++ b/frontend/src/components/common/DateRangePicker.vue
@@ -178,14 +178,14 @@ function validateTextDate(dateRangeToCheck: string): string | boolean {
   const isStartDateValid = isDateValid(startDateText);
   if (isStartDateValid) {
     const startDate = new Date(startDateText);
-    if (startDate < minDateProp.value) {
+    if (!isNil(minDateProp.value) && startDate < minDateProp.value) {
       const minDatePropText = minDateProp.value.toLocaleDateString(
         LOCAL_OPTIONS,
         options
       );
       return `Das gewählte Startdatum ist vor dem kleinstmöglichen Startdatum ${minDatePropText}`;
     }
-    if (startDate > maxDateProp.value) {
+    if (!isNil(maxDateProp.value) && startDate > maxDateProp.value) {
       const maxDatePropText = maxDateProp.value.toLocaleDateString(
         LOCAL_OPTIONS,
         options
@@ -198,14 +198,14 @@ function validateTextDate(dateRangeToCheck: string): string | boolean {
   const isEndDateValid = isDateValid(endDateText);
   if (isEndDateValid) {
     const endDate = new Date(endDateText);
-    if (endDate < minDateProp.value) {
+    if (!isNil(minDateProp.value) && endDate < minDateProp.value) {
       const minDatePropText = minDateProp.value.toLocaleDateString(
         LOCAL_OPTIONS,
         options
       );
       return `Das gewählte Enddatum ist vor dem kleinstmöglichen Startdatum ${minDatePropText}`;
     }
-    if (endDate > maxDateProp.value) {
+    if (!isNil(maxDateProp.value) && endDate > maxDateProp.value) {
       const maxDatePropText = maxDateProp.value.toLocaleDateString(
         LOCAL_OPTIONS,
         options

--- a/frontend/src/components/common/DateRangePicker.vue
+++ b/frontend/src/components/common/DateRangePicker.vue
@@ -1,15 +1,17 @@
 <template>
   <!-- https://vue3datepicker.com/ -->
   <vue-date-picker
-    v-model="date"
+    v-model="dateRange"
+    range
+    position="left"
+    :multi-calendars="MULTI_CALENDAR_OPTIONS"
     class="mb-3"
     placeholder="Datum eingeben ..."
     :config="GENERAL_DATE_PICKER_CONFIG"
     :text-input="TEXT_INPUT_OPTIONS"
     :locale="'de-DE'"
     :format="format"
-    :start-time="{ hours: 5, minutes: 0 }"
-    :enable-time-picker="true"
+    :enable-time-picker="false"
     :disabled="props.disabled"
     :required="props.required"
     :clearable="false"
@@ -50,12 +52,10 @@
 
 <script setup lang="ts">
 import type { GeneralConfig } from "@vuepic/vue-datepicker";
-
 import VueDatePicker from "@vuepic/vue-datepicker";
-
 import "@vuepic/vue-datepicker/dist/main.css";
-
 import { useDateUtils } from "@/util/DateUtils";
+import _ from "lodash";
 
 interface Props {
   label?: string; // Bezeichnung des Datumsfelds
@@ -76,7 +76,12 @@ const props = withDefaults(defineProps<Props>(), {
   required: false,
   disabled: false,
 });
-const date = defineModel<Date | undefined>();
+
+const dateRange = defineModel<Array<Date> | undefined>();
+
+const MULTI_CALENDAR_OPTIONS: any = {
+  solo: true,
+}
 
 // https://vue3datepicker.com/props/modes-configuration/#text-input-configuration
 const TEXT_INPUT_OPTIONS: any = {
@@ -92,10 +97,16 @@ const GENERAL_DATE_PICKER_CONFIG: GeneralConfig = {
 };
 
 // https://vue3datepicker.com/props/formatting/#format
-const format = (date: Date) => {
-  // Hack damit die Zeit korrekt umgerechnet wird.
-  date.setHours(5);
-  return date.toLocaleDateString("de-DE", options);
+const format = (dateRange: Array<Date>) => {
+  let dateRangeText = "";
+  if (!_.isEmpty(dateRange)) {
+    const firstDate = _.head(dateRange);
+    const firstDateText = _.isNil(firstDate) ? "" : firstDate.toLocaleDateString("de-DE", options);
+    const lastDate = _.last(dateRange);
+    const lastDateText = _.isNil(lastDate) ? "" : lastDate.toLocaleDateString("de-DE", options);
+    dateRangeText = `${firstDateText}  -  ${lastDateText}`;
+  }
+  return dateRangeText;
 };
 
 const dateUtils = useDateUtils();

--- a/frontend/src/components/common/DateRangePicker.vue
+++ b/frontend/src/components/common/DateRangePicker.vue
@@ -16,7 +16,8 @@
         :disabled="props.disabled"
         :required="props.required"
         :clearable="false"
-
+        :min-date="minDateProp"
+        :max-date="maxDateProp"
         :week-numbers="WEEN_NUMBER_OPTIONS"
         :six-weeks="SIX_WEEK_CALENDAR_OPTIONS"
         cancel-text="Abbrechen"
@@ -40,7 +41,6 @@
             density="compact"
             :model-value="value"
             variant="underlined"
-            validate-on="blur"
             clearable
             @blur="onBlur"
             @input="onInput"

--- a/frontend/src/components/common/DateRangePicker.vue
+++ b/frontend/src/components/common/DateRangePicker.vue
@@ -18,7 +18,7 @@
       :clearable="false"
       :min-date="minDateProp"
       :max-date="maxDateProp"
-      :week-numbers="WEEN_NUMBER_OPTIONS"
+      :week-numbers="WEEK_NUMBER_OPTIONS"
       :six-weeks="SIX_WEEK_CALENDAR_OPTIONS"
       cancel-text="Abbrechen"
       select-text="Datum Auswählen"
@@ -124,7 +124,7 @@ const LOCAL_OPTIONS: string = "de-DE";
 const SIX_WEEK_CALENDAR_OPTIONS: any = "center";
 
 // https://vue3datepicker.com/props/calendar-configuration/#week-numbers
-const WEEN_NUMBER_OPTIONS: any = {
+const WEEK_NUMBER_OPTIONS: any = {
   type: "iso",
 };
 

--- a/frontend/src/components/common/DateRangePicker.vue
+++ b/frontend/src/components/common/DateRangePicker.vue
@@ -61,6 +61,7 @@
 import type { GeneralConfig } from "@vuepic/vue-datepicker";
 
 import VueDatePicker from "@vuepic/vue-datepicker";
+
 import "@vuepic/vue-datepicker/dist/main.css";
 
 import _ from "lodash";
@@ -88,12 +89,16 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const minDateProp = computed(() => {
-  props.minDate.setHours(5);
+  if (!_.isNil(props.minDate)) {
+    props.minDate.setHours(5);
+  }
   return props.minDate;
 });
 
 const maxDateProp = computed(() => {
-  props.maxDate.setHours(5);
+  if (!_.isNil(props.maxDate)) {
+    props.maxDate.setHours(5);
+  }
   return props.maxDate;
 });
 
@@ -104,14 +109,18 @@ const choosenDates = computed({
     return _.isNil(dateRange.value)
       ? undefined
       : dateRange.value.map((date) => {
-          date.setHours(5);
+          if (!_.isNil(date)) {
+            date.setHours(5);
+          }
           return date;
         });
   },
 
   set(dates: Array<Date> | undefined) {
     dateRange.value = _.toArray(dates).map((date) => {
-      date.setHours(5);
+      if (!_.isNil(date)) {
+        date.setHours(5);
+      }
       return date;
     });
   },

--- a/frontend/src/components/common/DateRangePicker.vue
+++ b/frontend/src/components/common/DateRangePicker.vue
@@ -114,6 +114,7 @@ const choosenDates = computed({
   }
 });
 
+// https://vue3datepicker.com/props/localization/#locale
 const LOCAL_OPTIONS: string = "de-DE";
 
 // https://vue3datepicker.com/props/look-and-feel/#six-weeks

--- a/frontend/src/components/common/DateRangePicker.vue
+++ b/frontend/src/components/common/DateRangePicker.vue
@@ -166,11 +166,11 @@ function validateTextDate(dateRangeToCheck: string): string | boolean {
   if (startDateText != "unbekannt" && !_.isEmpty(startDateText) && !isNaN(startDate.valueOf())) {
     if (startDate < minDateProp.value) {
       const minDatePropText = minDateProp.value.toLocaleDateString("de-DE", options);
-      return `Das gewählte Startdatum ist vor dem kleinstmöglichen Startdatum ${minDatePropText}`
+      return `Das gewählte Startdatum ist vor dem kleinstmöglichen Startdatum ${minDatePropText}`;
     }
     if (startDate > maxDateProp.value) {
       const maxDatePropText = maxDateProp.value.toLocaleDateString("de-DE", options);
-      return `Das gewählte Startdatum ist nach dem höchstmöglichen Enddatum ${maxDatePropText}`
+      return `Das gewählte Startdatum ist nach dem höchstmöglichen Enddatum ${maxDatePropText}`;
     }
   }
 
@@ -180,11 +180,11 @@ function validateTextDate(dateRangeToCheck: string): string | boolean {
   if (endDateText != "unbekannt" && !_.isEmpty(endDateText) && !isNaN(endDate.valueOf())) {
     if (endDate < minDateProp.value) {
       const minDatePropText = minDateProp.value.toLocaleDateString("de-DE", options);
-      return `Das gewählte Enddatum ist vor dem kleinstmöglichen Startdatum ${minDatePropText}`
+      return `Das gewählte Enddatum ist vor dem kleinstmöglichen Startdatum ${minDatePropText}`;
     }
     if (endDate > maxDateProp.value) {
       const maxDatePropText = maxDateProp.value.toLocaleDateString("de-DE", options);
-      return `Das gewählte Enddatum ist nach dem höchstmöglichen Enddatum ${maxDatePropText}`
+      return `Das gewählte Enddatum ist nach dem höchstmöglichen Enddatum ${maxDatePropText}`;
     }
   }
 

--- a/frontend/src/components/common/DateRangePicker.vue
+++ b/frontend/src/components/common/DateRangePicker.vue
@@ -1,24 +1,25 @@
 <template>
   <!-- https://vue3datepicker.com/ -->
-  <vue-date-picker
-    v-model="dateRange"
-    range
-    position="left"
-    :multi-calendars="MULTI_CALENDAR_OPTIONS"
-    class="mb-3"
-    placeholder="Datum eingeben ..."
-    :config="GENERAL_DATE_PICKER_CONFIG"
-    :text-input="TEXT_INPUT_OPTIONS"
-    :locale="'de-DE'"
-    :format="format"
-    :enable-time-picker="false"
-    :disabled="props.disabled"
-    :required="props.required"
-    :clearable="false"
-    auto-apply
-  >
-    <template
-      #dp-input="{
+  <v-row class="mt-2 mb-3">
+    <vue-date-picker
+        v-model="dateRange"
+        range
+        utc
+        position="left"
+        :multi-calendars="MULTI_CALENDAR_OPTIONS"
+        class="mb-3"
+        placeholder="Datum eingeben ..."
+        :config="GENERAL_DATE_PICKER_CONFIG"
+        :text-input="TEXT_INPUT_OPTIONS"
+        :locale="'de-DE'"
+        :format="format"
+        :enable-time-picker="false"
+        :disabled="props.disabled"
+        :required="props.required"
+        :clearable="false"
+    >
+      <template
+          #dp-input="{
         value,
         onInput,
         onEnter,
@@ -29,33 +30,34 @@
         onPaste,
         onFocus,
       }"
-    >
-      <v-text-field
-        :label="label"
-        density="compact"
-        :model-value="value"
-        variant="underlined"
-        validate-on="blur"
-        :rules="[(toCheck: string) => validateTextDate(toCheck)]"
-        clearable
-        @blur="onBlur"
-        @input="onInput"
-        @click:clear="onClear"
-        @keyup.enter="onEnter"
-        @keyup.tab="onTab"
-        @keyup="onKeypress"
-        @paste="onPaste"
-        @focus="onFocus"
-      />
-    </template>
-  </vue-date-picker>
+      >
+        <v-text-field
+            :label="label"
+            density="compact"
+            :model-value="value"
+            variant="underlined"
+            validate-on="blur"
+            :rules="[(toCheck: string) => validateTextDate(toCheck)]"
+            clearable
+            @blur="onBlur"
+            @input="onInput"
+            @click:clear="onClear"
+            @keyup.enter="onEnter"
+            @keyup.tab="onTab"
+            @keyup="onKeypress"
+            @paste="onPaste"
+            @focus="onFocus"
+        />
+      </template>
+    </vue-date-picker>
+  </v-row>
 </template>
 
 <script setup lang="ts">
-import type { GeneralConfig } from "@vuepic/vue-datepicker";
+import type {GeneralConfig} from "@vuepic/vue-datepicker";
 import VueDatePicker from "@vuepic/vue-datepicker";
 import "@vuepic/vue-datepicker/dist/main.css";
-import { useDateUtils } from "@/util/DateUtils";
+import {useDateUtils} from "@/util/DateUtils";
 import _ from "lodash";
 
 interface Props {
@@ -88,7 +90,6 @@ const MULTI_CALENDAR_OPTIONS: any = {
 const TEXT_INPUT_OPTIONS: any = {
   enterSubmit: true,
   tabSubmit: true,
-  openMenu: "toggle",
   format: "dd.MM.yyyy",
 };
 
@@ -111,16 +112,33 @@ const format = (dateRange: Array<Date>) => {
 };
 
 const dateUtils = useDateUtils();
-function validateTextDate(toCheck: string) {
-  if (!toCheck) {
+
+function validateTextDate(dateRangeToCheck: string) {
+  if (!dateRangeToCheck) {
     return true;
   }
-  return (
-    dateUtils.isDateBetweenAsStrings(
-      dateUtils.formatDateAsStringToISO(toCheck),
-      props.minDate,
-      props.maxDate
-    ) || "Das eingegebene Datum liegt außerhalb des gültigen Bereichs."
-  );
+  const startAndEndDate = _.split(dateRangeToCheck, "-").map(date => date.trim());
+  const startDate = _.head(startAndEndDate);
+  let validationResult: boolean | string = true;
+  if (!_.isNil(startDate)) {
+    validationResult = (
+        dateUtils.isDateBetweenAsStrings(
+            dateUtils.formatDateAsStringToISO(startDate),
+            props.minDate,
+            props.maxDate
+        ) || "Das Startdatum liegt außerhalb des gültigen Bereichs."
+    );
+  }
+  const endDate = _.head(startAndEndDate);
+  if (!_.isNil(endDate)) {
+    validationResult = (
+        dateUtils.isDateBetweenAsStrings(
+            dateUtils.formatDateAsStringToISO(endDate),
+            props.minDate,
+            props.maxDate
+        ) || "Das Enddatum liegt außerhalb des gültigen Bereichs."
+    );
+  }
+  return validationResult;
 }
 </script>

--- a/frontend/src/components/common/DateRangePicker.vue
+++ b/frontend/src/components/common/DateRangePicker.vue
@@ -1,60 +1,58 @@
 <template>
   <!-- https://vue3datepicker.com/ -->
-  <v-row class="ml-1 mt-2 mb-3">
-    <vue-date-picker
-      v-model="choosenDates"
-      range
-      position="left"
-      :multi-calendars="MULTI_CALENDAR_OPTIONS"
-      class="mb-3"
-      placeholder="Datum eingeben ..."
-      :config="GENERAL_DATE_PICKER_CONFIG"
-      :text-input="TEXT_INPUT_OPTIONS"
-      :locale="LOCAL_OPTIONS"
-      :format="format"
-      :enable-time-picker="false"
-      :disabled="props.disabled"
-      :required="props.required"
-      :clearable="false"
-      :min-date="minDateProp"
-      :max-date="maxDateProp"
-      :week-numbers="WEEK_NUMBER_OPTIONS"
-      :six-weeks="SIX_WEEK_CALENDAR_OPTIONS"
-      cancel-text="Abbrechen"
-      select-text="Datum Auswählen"
+  <vue-date-picker
+    class="ml-1 mt-2 mb-3"
+    v-model="choosenDates"
+    range
+    position="left"
+    :multi-calendars="MULTI_CALENDAR_OPTIONS"
+    placeholder="Datum eingeben ..."
+    :config="GENERAL_DATE_PICKER_CONFIG"
+    :text-input="TEXT_INPUT_OPTIONS"
+    :locale="LOCAL_OPTIONS"
+    :format="format"
+    :enable-time-picker="false"
+    :disabled="props.disabled"
+    :required="props.required"
+    :clearable="false"
+    :min-date="minDateProp"
+    :max-date="maxDateProp"
+    :week-numbers="WEEK_NUMBER_OPTIONS"
+    :six-weeks="SIX_WEEK_CALENDAR_OPTIONS"
+    cancel-text="Abbrechen"
+    select-text="Datum Auswählen"
+  >
+    <template
+      #dp-input="{
+        value,
+        onInput,
+        onEnter,
+        onTab,
+        onClear,
+        onBlur,
+        onKeypress,
+        onPaste,
+        onFocus,
+      }"
     >
-      <template
-        #dp-input="{
-          value,
-          onInput,
-          onEnter,
-          onTab,
-          onClear,
-          onBlur,
-          onKeypress,
-          onPaste,
-          onFocus,
-        }"
-      >
-        <v-text-field
-          :label="label"
-          density="compact"
-          :model-value="value"
-          variant="underlined"
-          clearable
-          @blur="onBlur"
-          @input="onInput"
-          :rules="[(toCheck: string) => validateTextDate(toCheck)]"
-          @click:clear="onClear"
-          @keyup.enter="onEnter"
-          @keyup.tab="onTab"
-          @keyup="onKeypress"
-          @paste="onPaste"
-          @focus="onFocus"
-        />
-      </template>
-    </vue-date-picker>
-  </v-row>
+      <v-text-field
+        :label="label"
+        density="compact"
+        :model-value="value"
+        variant="underlined"
+        clearable
+        @blur="onBlur"
+        @input="onInput"
+        :rules="[(toCheck: string) => validateTextDate(toCheck)]"
+        @click:clear="onClear"
+        @keyup.enter="onEnter"
+        @keyup.tab="onTab"
+        @keyup="onKeypress"
+        @paste="onPaste"
+        @focus="onFocus"
+      />
+    </template>
+  </vue-date-picker>
 </template>
 
 <script setup lang="ts">

--- a/frontend/src/components/common/DateRangePicker.vue
+++ b/frontend/src/components/common/DateRangePicker.vue
@@ -61,7 +61,6 @@
 import type { GeneralConfig } from "@vuepic/vue-datepicker";
 
 import VueDatePicker from "@vuepic/vue-datepicker";
-
 import "@vuepic/vue-datepicker/dist/main.css";
 
 import _ from "lodash";

--- a/frontend/src/components/common/DateRangePicker.vue
+++ b/frontend/src/components/common/DateRangePicker.vue
@@ -1,10 +1,9 @@
 <template>
   <!-- https://vue3datepicker.com/ -->
-  <v-row class="mt-2 mb-3">
+  <v-row class="ml-1 mt-2 mb-3">
     <vue-date-picker
-        v-model="dateRange"
+        v-model="choosenDates"
         range
-        utc
         position="left"
         :multi-calendars="MULTI_CALENDAR_OPTIONS"
         class="mb-3"
@@ -17,6 +16,8 @@
         :disabled="props.disabled"
         :required="props.required"
         :clearable="false"
+        cancel-text="Abbrechen"
+        select-text="Datum Auswählen"
     >
       <template
           #dp-input="{
@@ -59,6 +60,7 @@ import VueDatePicker from "@vuepic/vue-datepicker";
 import "@vuepic/vue-datepicker/dist/main.css";
 import {useDateUtils} from "@/util/DateUtils";
 import _ from "lodash";
+import {computed} from "vue";
 
 interface Props {
   label?: string; // Bezeichnung des Datumsfelds
@@ -81,6 +83,24 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const dateRange = defineModel<Array<Date> | undefined>();
+
+const choosenDates = computed({
+  get() {
+    return _.isNil(dateRange.value)
+        ? undefined
+        : dateRange.value.map(date => {
+          date.setHours(5);
+          return date;
+        });
+  },
+
+  set(dates: Array<Date> | undefined) {
+    dateRange.value = _.toArray(dates).map(date => {
+      date.setHours(5);
+      return date;
+    });
+  }
+});
 
 const MULTI_CALENDAR_OPTIONS: any = {
   solo: true,

--- a/frontend/src/components/common/DateRangePicker.vue
+++ b/frontend/src/components/common/DateRangePicker.vue
@@ -2,29 +2,29 @@
   <!-- https://vue3datepicker.com/ -->
   <v-row class="ml-1 mt-2 mb-3">
     <vue-date-picker
-        v-model="choosenDates"
-        range
-        position="left"
-        :multi-calendars="MULTI_CALENDAR_OPTIONS"
-        class="mb-3"
-        placeholder="Datum eingeben ..."
-        :config="GENERAL_DATE_PICKER_CONFIG"
-        :text-input="TEXT_INPUT_OPTIONS"
-        :locale="LOCAL_OPTIONS"
-        :format="format"
-        :enable-time-picker="false"
-        :disabled="props.disabled"
-        :required="props.required"
-        :clearable="false"
-        :min-date="minDateProp"
-        :max-date="maxDateProp"
-        :week-numbers="WEEN_NUMBER_OPTIONS"
-        :six-weeks="SIX_WEEK_CALENDAR_OPTIONS"
-        cancel-text="Abbrechen"
-        select-text="Datum Auswählen"
+      v-model="choosenDates"
+      range
+      position="left"
+      :multi-calendars="MULTI_CALENDAR_OPTIONS"
+      class="mb-3"
+      placeholder="Datum eingeben ..."
+      :config="GENERAL_DATE_PICKER_CONFIG"
+      :text-input="TEXT_INPUT_OPTIONS"
+      :locale="LOCAL_OPTIONS"
+      :format="format"
+      :enable-time-picker="false"
+      :disabled="props.disabled"
+      :required="props.required"
+      :clearable="false"
+      :min-date="minDateProp"
+      :max-date="maxDateProp"
+      :week-numbers="WEEN_NUMBER_OPTIONS"
+      :six-weeks="SIX_WEEK_CALENDAR_OPTIONS"
+      cancel-text="Abbrechen"
+      select-text="Datum Auswählen"
     >
       <template
-          #dp-input="{
+        #dp-input="{
         value,
         onInput,
         onEnter,
@@ -37,20 +37,20 @@
       }"
       >
         <v-text-field
-            :label="label"
-            density="compact"
-            :model-value="value"
-            variant="underlined"
-            clearable
-            @blur="onBlur"
-            @input="onInput"
-            :rules="[(toCheck: string) => validateTextDate(toCheck)]"
-            @click:clear="onClear"
-            @keyup.enter="onEnter"
-            @keyup.tab="onTab"
-            @keyup="onKeypress"
-            @paste="onPaste"
-            @focus="onFocus"
+          :label="label"
+          density="compact"
+          :model-value="value"
+          variant="underlined"
+          clearable
+          @blur="onBlur"
+          @input="onInput"
+          :rules="[(toCheck: string) => validateTextDate(toCheck)]"
+          @click:clear="onClear"
+          @keyup.enter="onEnter"
+          @keyup.tab="onTab"
+          @keyup="onKeypress"
+          @paste="onPaste"
+          @focus="onFocus"
         />
       </template>
     </vue-date-picker>
@@ -58,12 +58,12 @@
 </template>
 
 <script setup lang="ts">
-import type {GeneralConfig} from "@vuepic/vue-datepicker";
+import type { GeneralConfig } from "@vuepic/vue-datepicker";
 import VueDatePicker from "@vuepic/vue-datepicker";
 import "@vuepic/vue-datepicker/dist/main.css";
 import _ from "lodash";
-import {computed, ref} from "vue";
-import {useDateUtils} from "@/util/DateUtils";
+import { computed } from "vue";
+import { useDateUtils } from "@/util/DateUtils";
 
 interface Props {
   label?: string; // Bezeichnung des Datumsfelds
@@ -76,35 +76,35 @@ interface Props {
 const options: Intl.DateTimeFormatOptions = {
   year: "numeric",
   month: "2-digit",
-  day: "2-digit",
+  day: "2-digit"
 };
 
 const props = withDefaults(defineProps<Props>(), {
   label: "",
   required: false,
-  disabled: false,
+  disabled: false
 });
 
 const minDateProp = computed(() => {
   props.minDate.setHours(5);
   return props.minDate;
-})
+});
 
 const maxDateProp = computed(() => {
   props.maxDate.setHours(5);
   return props.maxDate;
-})
+});
 
 const dateRange = defineModel<Array<Date> | undefined>();
 
 const choosenDates = computed({
   get() {
     return _.isNil(dateRange.value)
-        ? undefined
-        : dateRange.value.map(date => {
-          date.setHours(5);
-          return date;
-        });
+      ? undefined
+      : dateRange.value.map(date => {
+        date.setHours(5);
+        return date;
+      });
   },
 
   set(dates: Array<Date> | undefined) {
@@ -119,28 +119,28 @@ const choosenDates = computed({
 const LOCAL_OPTIONS: string = "de-DE";
 
 // https://vue3datepicker.com/props/look-and-feel/#six-weeks
-const SIX_WEEK_CALENDAR_OPTIONS: any = 'center';
+const SIX_WEEK_CALENDAR_OPTIONS: any = "center";
 
 // https://vue3datepicker.com/props/calendar-configuration/#week-numbers
 const WEEN_NUMBER_OPTIONS: any = {
-  type: "iso",
-}
+  type: "iso"
+};
 
 // https://vue3datepicker.com/props/modes-configuration/#multi-calendars-configuration
 const MULTI_CALENDAR_OPTIONS: any = {
-  solo: true,
-}
+  solo: true
+};
 
 // https://vue3datepicker.com/props/modes-configuration/#text-input-configuration
 const TEXT_INPUT_OPTIONS: any = {
   enterSubmit: true,
   tabSubmit: true,
-  format: "dd.MM.yyyy",
+  format: "dd.MM.yyyy"
 };
 
 // https://vue3datepicker.com/props/general-configuration/#config
 const GENERAL_DATE_PICKER_CONFIG: GeneralConfig = {
-  setDateOnMenuClose: true,
+  setDateOnMenuClose: true
 };
 
 // https://vue3datepicker.com/props/formatting/#format
@@ -156,12 +156,11 @@ const format = (dateRange: Array<Date>) => {
   return dateRangeText;
 };
 
-const dateUtils = useDateUtils();
 function validateTextDate(dateRangeToCheck: string): string | boolean {
   const startAndEndDate = _.split(dateRangeToCheck, "-").map(date => date.trim());
 
-  let startDateText =  _.toString(_.head(startAndEndDate));
-  startDateText = dateUtils.formatDateAsStringToISO(startDateText);
+  let startDateText = _.toString(_.head(startAndEndDate));
+  startDateText = useDateUtils().formatDateAsStringToISO(startDateText);
   const startDate = new Date(startDateText);
   if (startDateText != "unbekannt" && !_.isEmpty(startDateText) && !isNaN(startDate.valueOf())) {
     if (startDate < minDateProp.value) {
@@ -175,7 +174,7 @@ function validateTextDate(dateRangeToCheck: string): string | boolean {
   }
 
   let endDateText = _.toString(_.last(startAndEndDate));
-  endDateText = dateUtils.formatDateAsStringToISO(endDateText);
+  endDateText = useDateUtils().formatDateAsStringToISO(endDateText);
   const endDate = new Date(endDateText);
   if (endDateText != "unbekannt" && !_.isEmpty(endDateText) && !isNaN(endDate.valueOf())) {
     if (endDate < minDateProp.value) {

--- a/frontend/src/components/common/DateRangePicker.vue
+++ b/frontend/src/components/common/DateRangePicker.vue
@@ -45,6 +45,7 @@
             clearable
             @blur="onBlur"
             @input="onInput"
+            :rules="[(toCheck: string) => validateTextDate(toCheck)]"
             @click:clear="onClear"
             @keyup.enter="onEnter"
             @keyup.tab="onTab"
@@ -154,4 +155,36 @@ const format = (dateRange: Array<Date>) => {
   }
   return dateRangeText;
 };
+
+function validateTextDate(dateRangeToCheck: string): string | boolean {
+  const startAndEndDate = _.split(dateRangeToCheck, "-").map(date => date.trim());
+
+  const startDateText =  _.toString(_.head(startAndEndDate));
+  const startDate = new Date(startDateText);
+  if (!_.isEmpty(startDate) && !isNaN(startDate.valueOf())) {
+    if (startDate < minDateProp.value) {
+      const minDatePropText = minDateProp.value.toLocaleDateString("de-DE", options);
+      return `Das gewählte Startdatum ist vor dem kleinstmöglichen Startdatum ${minDatePropText}`
+    }
+    if (startDate > maxDateProp.value) {
+      const maxDatePropText = maxDateProp.value.toLocaleDateString("de-DE", options);
+      return `Das gewählte Startdatum ist nach dem höchstmöglichen Enddatum ${maxDatePropText}`
+    }
+  }
+
+  const endDateText = _.toString(_.last(startAndEndDate));
+  const endDate = new Date(endDateText);
+  if (!_.isEmpty(endDateText) && !isNaN(endDate.valueOf())) {
+    if (endDate < minDateProp.value) {
+      const minDatePropText = minDateProp.value.toLocaleDateString("de-DE", options);
+      return `Das gewählte Enddatum ist vor dem kleinstmöglichen Startdatum ${minDatePropText}`
+    }
+    if (endDate > maxDateProp.value) {
+      const maxDatePropText = maxDateProp.value.toLocaleDateString("de-DE", options);
+      return `Das gewählte Enddatum ist nach dem höchstmöglichen Enddatum ${maxDatePropText}`
+    }
+  }
+
+  return true;
+}
 </script>

--- a/frontend/src/components/common/DateRangePicker.vue
+++ b/frontend/src/components/common/DateRangePicker.vue
@@ -18,6 +18,8 @@
         :clearable="false"
         :min-date="minDateProp"
         :max-date="maxDateProp"
+        :week-numbers="WEEN_NUMBER_OPTIONS"
+        :six-weeks="SIX_WEEK_CALENDAR_OPTIONS"
         cancel-text="Abbrechen"
         select-text="Datum Auswählen"
     >
@@ -59,9 +61,8 @@
 import type {GeneralConfig} from "@vuepic/vue-datepicker";
 import VueDatePicker from "@vuepic/vue-datepicker";
 import "@vuepic/vue-datepicker/dist/main.css";
-import {useDateUtils} from "@/util/DateUtils";
 import _ from "lodash";
-import {computed} from "vue";
+import {computed, ref} from "vue";
 
 interface Props {
   label?: string; // Bezeichnung des Datumsfelds
@@ -112,6 +113,14 @@ const choosenDates = computed({
     });
   }
 });
+
+// https://vue3datepicker.com/props/look-and-feel/#six-weeks
+const SIX_WEEK_CALENDAR_OPTIONS: any = 'center';
+
+// https://vue3datepicker.com/props/calendar-configuration/#week-numbers
+const WEEN_NUMBER_OPTIONS: any = {
+  type: "iso",
+}
 
 // https://vue3datepicker.com/props/modes-configuration/#multi-calendars-configuration
 const MULTI_CALENDAR_OPTIONS: any = {

--- a/frontend/src/components/common/DateRangePicker.vue
+++ b/frontend/src/components/common/DateRangePicker.vue
@@ -10,7 +10,7 @@
         placeholder="Datum eingeben ..."
         :config="GENERAL_DATE_PICKER_CONFIG"
         :text-input="TEXT_INPUT_OPTIONS"
-        :locale="'de-DE'"
+        :locale="LOCAL_OPTIONS"
         :format="format"
         :enable-time-picker="false"
         :disabled="props.disabled"
@@ -114,6 +114,8 @@ const choosenDates = computed({
   }
 });
 
+const LOCAL_OPTIONS: string = "de-DE";
+
 // https://vue3datepicker.com/props/look-and-feel/#six-weeks
 const SIX_WEEK_CALENDAR_OPTIONS: any = 'center';
 
@@ -144,9 +146,9 @@ const format = (dateRange: Array<Date>) => {
   let dateRangeText = "";
   if (!_.isEmpty(dateRange)) {
     const firstDate = _.head(dateRange);
-    const firstDateText = _.isNil(firstDate) ? "" : firstDate.toLocaleDateString("de-DE", options);
+    const firstDateText = _.isNil(firstDate) ? "" : firstDate.toLocaleDateString(LOCAL_OPTIONS, options);
     const lastDate = _.last(dateRange);
-    const lastDateText = _.isNil(lastDate) ? "" : lastDate.toLocaleDateString("de-DE", options);
+    const lastDateText = _.isNil(lastDate) ? "" : lastDate.toLocaleDateString(LOCAL_OPTIONS, options);
     dateRangeText = `${firstDateText}  -  ${lastDateText}`;
   }
   return dateRangeText;

--- a/frontend/src/components/common/DateRangePicker.vue
+++ b/frontend/src/components/common/DateRangePicker.vue
@@ -173,14 +173,14 @@ function validateTextDate(dateRangeToCheck: string): string | boolean {
   if (isStartDateValid) {
     if (startDate < minDateProp.value) {
       const minDatePropText = minDateProp.value.toLocaleDateString(
-        "de-DE",
+        LOCAL_OPTIONS,
         options
       );
       return `Das gewählte Startdatum ist vor dem kleinstmöglichen Startdatum ${minDatePropText}`;
     }
     if (startDate > maxDateProp.value) {
       const maxDatePropText = maxDateProp.value.toLocaleDateString(
-        "de-DE",
+        LOCAL_OPTIONS,
         options
       );
       return `Das gewählte Startdatum ist nach dem höchstmöglichen Enddatum ${maxDatePropText}`;
@@ -193,14 +193,14 @@ function validateTextDate(dateRangeToCheck: string): string | boolean {
   if (isEndDateValid) {
     if (endDate < minDateProp.value) {
       const minDatePropText = minDateProp.value.toLocaleDateString(
-        "de-DE",
+        LOCAL_OPTIONS,
         options
       );
       return `Das gewählte Enddatum ist vor dem kleinstmöglichen Startdatum ${minDatePropText}`;
     }
     if (endDate > maxDateProp.value) {
       const maxDatePropText = maxDateProp.value.toLocaleDateString(
-        "de-DE",
+        LOCAL_OPTIONS,
         options
       );
       return `Das gewählte Enddatum ist nach dem höchstmöglichen Enddatum ${maxDatePropText}`;

--- a/frontend/src/components/common/DateRangePicker.vue
+++ b/frontend/src/components/common/DateRangePicker.vue
@@ -175,9 +175,9 @@ function validateTextDate(dateRangeToCheck: string): string | boolean {
   );
 
   const startDateText = _.toString(_.head(startAndEndDate));
-  const isStartDateValid = moment(startDateText, "DD.MM.YYYY", true).isValid();
-  const startDate = new Date(startDateText);
+  const isStartDateValid = isDateValid(startDateText);
   if (isStartDateValid) {
+    const startDate = new Date(startDateText);
     if (startDate < minDateProp.value) {
       const minDatePropText = minDateProp.value.toLocaleDateString(
         LOCAL_OPTIONS,
@@ -195,9 +195,9 @@ function validateTextDate(dateRangeToCheck: string): string | boolean {
   }
 
   const endDateText = _.toString(_.last(startAndEndDate));
-  const isEndDateValid = moment(endDateText, "DD.MM.YYYY", true).isValid();
-  const endDate = new Date(endDateText);
+  const isEndDateValid = isDateValid(endDateText);
   if (isEndDateValid) {
+    const endDate = new Date(endDateText);
     if (endDate < minDateProp.value) {
       const minDatePropText = minDateProp.value.toLocaleDateString(
         LOCAL_OPTIONS,
@@ -215,5 +215,9 @@ function validateTextDate(dateRangeToCheck: string): string | boolean {
   }
 
   return true;
+}
+
+function isDateValid(date: string): boolean {
+  return moment(date, "DD.MM.YYYY", true).isValid();
 }
 </script>

--- a/frontend/src/components/common/DateRangePicker.vue
+++ b/frontend/src/components/common/DateRangePicker.vue
@@ -35,6 +35,7 @@
         density="compact"
         :model-value="value"
         variant="underlined"
+        validate-on="blur"
         :rules="[(toCheck: string) => validateTextDate(toCheck)]"
         clearable
         @blur="onBlur"

--- a/frontend/src/components/common/DateRangePicker.vue
+++ b/frontend/src/components/common/DateRangePicker.vue
@@ -16,6 +16,8 @@
         :disabled="props.disabled"
         :required="props.required"
         :clearable="false"
+        :min-date="minDateProp"
+        :max-date="maxDateProp"
         cancel-text="Abbrechen"
         select-text="Datum Auswählen"
     >
@@ -38,7 +40,6 @@
             :model-value="value"
             variant="underlined"
             validate-on="blur"
-            :rules="[(toCheck: string) => validateTextDate(toCheck)]"
             clearable
             @blur="onBlur"
             @input="onInput"
@@ -66,8 +67,8 @@ interface Props {
   label?: string; // Bezeichnung des Datumsfelds
   required?: boolean; // Ist das Datumsfeld ein Pflichtfeld
   disabled?: boolean; // Ob das Datumsfeld deaktiviert sein soll
-  minDate: string; // Ob das Datumsfeld deaktiviert sein soll
-  maxDate: string; // Ob das Datumsfeld deaktiviert sein soll
+  minDate: Date; // Ob das Datumsfeld deaktiviert sein soll
+  maxDate: Date; // Ob das Datumsfeld deaktiviert sein soll
 }
 
 const options: Intl.DateTimeFormatOptions = {
@@ -81,6 +82,16 @@ const props = withDefaults(defineProps<Props>(), {
   required: false,
   disabled: false,
 });
+
+const minDateProp = computed(() => {
+  props.minDate.setHours(5);
+  return props.minDate;
+})
+
+const maxDateProp = computed(() => {
+  props.maxDate.setHours(5);
+  return props.maxDate;
+})
 
 const dateRange = defineModel<Array<Date> | undefined>();
 
@@ -102,6 +113,7 @@ const choosenDates = computed({
   }
 });
 
+// https://vue3datepicker.com/props/modes-configuration/#multi-calendars-configuration
 const MULTI_CALENDAR_OPTIONS: any = {
   solo: true,
 }
@@ -130,35 +142,4 @@ const format = (dateRange: Array<Date>) => {
   }
   return dateRangeText;
 };
-
-const dateUtils = useDateUtils();
-
-function validateTextDate(dateRangeToCheck: string) {
-  if (!dateRangeToCheck) {
-    return true;
-  }
-  const startAndEndDate = _.split(dateRangeToCheck, "-").map(date => date.trim());
-  const startDate = _.head(startAndEndDate);
-  let validationResult: boolean | string = true;
-  if (!_.isNil(startDate)) {
-    validationResult = (
-        dateUtils.isDateBetweenAsStrings(
-            dateUtils.formatDateAsStringToISO(startDate),
-            props.minDate,
-            props.maxDate
-        ) || "Das Startdatum liegt außerhalb des gültigen Bereichs."
-    );
-  }
-  const endDate = _.head(startAndEndDate);
-  if (!_.isNil(endDate)) {
-    validationResult = (
-        dateUtils.isDateBetweenAsStrings(
-            dateUtils.formatDateAsStringToISO(endDate),
-            props.minDate,
-            props.maxDate
-        ) || "Das Enddatum liegt außerhalb des gültigen Bereichs."
-    );
-  }
-  return validationResult;
-}
 </script>

--- a/frontend/src/components/common/DateRangePicker.vue
+++ b/frontend/src/components/common/DateRangePicker.vue
@@ -63,7 +63,7 @@ import VueDatePicker from "@vuepic/vue-datepicker";
 import "@vuepic/vue-datepicker/dist/main.css";
 import _ from "lodash";
 import { computed } from "vue";
-import { useDateUtils } from "@/util/DateUtils";
+import moment from "moment";
 
 interface Props {
   label?: string; // Bezeichnung des Datumsfelds
@@ -159,10 +159,10 @@ const format = (dateRange: Array<Date>) => {
 function validateTextDate(dateRangeToCheck: string): string | boolean {
   const startAndEndDate = _.split(dateRangeToCheck, "-").map(date => date.trim());
 
-  let startDateText = _.toString(_.head(startAndEndDate));
-  startDateText = useDateUtils().formatDateAsStringToISO(startDateText);
+  const startDateText = _.toString(_.head(startAndEndDate));
+  const isStartDateValid = moment(startDateText, "DD.MM.YYYY", true).isValid();
   const startDate = new Date(startDateText);
-  if (startDateText != "unbekannt" && !_.isEmpty(startDateText) && !isNaN(startDate.valueOf())) {
+  if (isStartDateValid) {
     if (startDate < minDateProp.value) {
       const minDatePropText = minDateProp.value.toLocaleDateString("de-DE", options);
       return `Das gewählte Startdatum ist vor dem kleinstmöglichen Startdatum ${minDatePropText}`;
@@ -173,10 +173,10 @@ function validateTextDate(dateRangeToCheck: string): string | boolean {
     }
   }
 
-  let endDateText = _.toString(_.last(startAndEndDate));
-  endDateText = useDateUtils().formatDateAsStringToISO(endDateText);
+  const endDateText = _.toString(_.last(startAndEndDate));
+  const isEndDateValid = moment(endDateText, "DD.MM.YYYY", true).isValid();
   const endDate = new Date(endDateText);
-  if (endDateText != "unbekannt" && !_.isEmpty(endDateText) && !isNaN(endDate.valueOf())) {
+  if (isEndDateValid) {
     if (endDate < minDateProp.value) {
       const minDatePropText = minDateProp.value.toLocaleDateString("de-DE", options);
       return `Das gewählte Enddatum ist vor dem kleinstmöglichen Startdatum ${minDatePropText}`;

--- a/frontend/src/components/common/DateRangePicker.vue
+++ b/frontend/src/components/common/DateRangePicker.vue
@@ -62,7 +62,7 @@ import VueDatePicker from "@vuepic/vue-datepicker";
 
 import "@vuepic/vue-datepicker/dist/main.css";
 
-import _ from "lodash";
+import { head, isEmpty, isNil, last, split, toArray, toString } from "lodash";
 import moment from "moment";
 import { computed } from "vue";
 
@@ -87,14 +87,14 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const minDateProp = computed(() => {
-  if (!_.isNil(props.minDate)) {
+  if (!isNil(props.minDate)) {
     props.minDate.setHours(5);
   }
   return props.minDate;
 });
 
 const maxDateProp = computed(() => {
-  if (!_.isNil(props.maxDate)) {
+  if (!isNil(props.maxDate)) {
     props.maxDate.setHours(5);
   }
   return props.maxDate;
@@ -104,10 +104,10 @@ const dateRange = defineModel<Array<Date> | undefined>();
 
 const choosenDates = computed({
   get() {
-    return _.isNil(dateRange.value)
+    return isNil(dateRange.value)
       ? undefined
       : dateRange.value.map((date) => {
-          if (!_.isNil(date)) {
+          if (!isNil(date)) {
             date.setHours(5);
           }
           return date;
@@ -115,8 +115,8 @@ const choosenDates = computed({
   },
 
   set(dates: Array<Date> | undefined) {
-    dateRange.value = _.toArray(dates).map((date) => {
-      if (!_.isNil(date)) {
+    dateRange.value = toArray(dates).map((date) => {
+      if (!isNil(date)) {
         date.setHours(5);
       }
       return date;
@@ -155,13 +155,13 @@ const GENERAL_DATE_PICKER_CONFIG: GeneralConfig = {
 // https://vue3datepicker.com/props/formatting/#format
 const format = (dateRange: Array<Date>) => {
   let dateRangeText = "";
-  if (!_.isEmpty(dateRange)) {
-    const firstDate = _.head(dateRange);
-    const firstDateText = _.isNil(firstDate)
+  if (!isEmpty(dateRange)) {
+    const firstDate = head(dateRange);
+    const firstDateText = isNil(firstDate)
       ? ""
       : firstDate.toLocaleDateString(LOCAL_OPTIONS, options);
-    const lastDate = _.last(dateRange);
-    const lastDateText = _.isNil(lastDate)
+    const lastDate = last(dateRange);
+    const lastDateText = isNil(lastDate)
       ? ""
       : lastDate.toLocaleDateString(LOCAL_OPTIONS, options);
     dateRangeText = `${firstDateText}  -  ${lastDateText}`;
@@ -170,11 +170,11 @@ const format = (dateRange: Array<Date>) => {
 };
 
 function validateTextDate(dateRangeToCheck: string): string | boolean {
-  const startAndEndDate = _.split(dateRangeToCheck, "-").map((date) =>
+  const startAndEndDate = split(dateRangeToCheck, "-").map((date) =>
     date.trim()
   );
 
-  const startDateText = _.toString(_.head(startAndEndDate));
+  const startDateText = toString(head(startAndEndDate));
   const isStartDateValid = isDateValid(startDateText);
   if (isStartDateValid) {
     const startDate = new Date(startDateText);
@@ -194,7 +194,7 @@ function validateTextDate(dateRangeToCheck: string): string | boolean {
     }
   }
 
-  const endDateText = _.toString(_.last(startAndEndDate));
+  const endDateText = toString(last(startAndEndDate));
   const isEndDateValid = isDateValid(endDateText);
   if (isEndDateValid) {
     const endDate = new Date(endDateText);

--- a/frontend/src/components/common/DateRangePicker.vue
+++ b/frontend/src/components/common/DateRangePicker.vue
@@ -25,16 +25,16 @@
     >
       <template
         #dp-input="{
-        value,
-        onInput,
-        onEnter,
-        onTab,
-        onClear,
-        onBlur,
-        onKeypress,
-        onPaste,
-        onFocus,
-      }"
+          value,
+          onInput,
+          onEnter,
+          onTab,
+          onClear,
+          onBlur,
+          onKeypress,
+          onPaste,
+          onFocus,
+        }"
       >
         <v-text-field
           :label="label"
@@ -59,11 +59,14 @@
 
 <script setup lang="ts">
 import type { GeneralConfig } from "@vuepic/vue-datepicker";
+
 import VueDatePicker from "@vuepic/vue-datepicker";
+
 import "@vuepic/vue-datepicker/dist/main.css";
+
 import _ from "lodash";
-import { computed } from "vue";
 import moment from "moment";
+import { computed } from "vue";
 
 interface Props {
   label?: string; // Bezeichnung des Datumsfelds
@@ -76,13 +79,13 @@ interface Props {
 const options: Intl.DateTimeFormatOptions = {
   year: "numeric",
   month: "2-digit",
-  day: "2-digit"
+  day: "2-digit",
 };
 
 const props = withDefaults(defineProps<Props>(), {
   label: "",
   required: false,
-  disabled: false
+  disabled: false,
 });
 
 const minDateProp = computed(() => {
@@ -101,18 +104,18 @@ const choosenDates = computed({
   get() {
     return _.isNil(dateRange.value)
       ? undefined
-      : dateRange.value.map(date => {
-        date.setHours(5);
-        return date;
-      });
+      : dateRange.value.map((date) => {
+          date.setHours(5);
+          return date;
+        });
   },
 
   set(dates: Array<Date> | undefined) {
-    dateRange.value = _.toArray(dates).map(date => {
+    dateRange.value = _.toArray(dates).map((date) => {
       date.setHours(5);
       return date;
     });
-  }
+  },
 });
 
 // https://vue3datepicker.com/props/localization/#locale
@@ -123,24 +126,24 @@ const SIX_WEEK_CALENDAR_OPTIONS: any = "center";
 
 // https://vue3datepicker.com/props/calendar-configuration/#week-numbers
 const WEEN_NUMBER_OPTIONS: any = {
-  type: "iso"
+  type: "iso",
 };
 
 // https://vue3datepicker.com/props/modes-configuration/#multi-calendars-configuration
 const MULTI_CALENDAR_OPTIONS: any = {
-  solo: true
+  solo: true,
 };
 
 // https://vue3datepicker.com/props/modes-configuration/#text-input-configuration
 const TEXT_INPUT_OPTIONS: any = {
   enterSubmit: true,
   tabSubmit: true,
-  format: "dd.MM.yyyy"
+  format: "dd.MM.yyyy",
 };
 
 // https://vue3datepicker.com/props/general-configuration/#config
 const GENERAL_DATE_PICKER_CONFIG: GeneralConfig = {
-  setDateOnMenuClose: true
+  setDateOnMenuClose: true,
 };
 
 // https://vue3datepicker.com/props/formatting/#format
@@ -148,27 +151,39 @@ const format = (dateRange: Array<Date>) => {
   let dateRangeText = "";
   if (!_.isEmpty(dateRange)) {
     const firstDate = _.head(dateRange);
-    const firstDateText = _.isNil(firstDate) ? "" : firstDate.toLocaleDateString(LOCAL_OPTIONS, options);
+    const firstDateText = _.isNil(firstDate)
+      ? ""
+      : firstDate.toLocaleDateString(LOCAL_OPTIONS, options);
     const lastDate = _.last(dateRange);
-    const lastDateText = _.isNil(lastDate) ? "" : lastDate.toLocaleDateString(LOCAL_OPTIONS, options);
+    const lastDateText = _.isNil(lastDate)
+      ? ""
+      : lastDate.toLocaleDateString(LOCAL_OPTIONS, options);
     dateRangeText = `${firstDateText}  -  ${lastDateText}`;
   }
   return dateRangeText;
 };
 
 function validateTextDate(dateRangeToCheck: string): string | boolean {
-  const startAndEndDate = _.split(dateRangeToCheck, "-").map(date => date.trim());
+  const startAndEndDate = _.split(dateRangeToCheck, "-").map((date) =>
+    date.trim()
+  );
 
   const startDateText = _.toString(_.head(startAndEndDate));
   const isStartDateValid = moment(startDateText, "DD.MM.YYYY", true).isValid();
   const startDate = new Date(startDateText);
   if (isStartDateValid) {
     if (startDate < minDateProp.value) {
-      const minDatePropText = minDateProp.value.toLocaleDateString("de-DE", options);
+      const minDatePropText = minDateProp.value.toLocaleDateString(
+        "de-DE",
+        options
+      );
       return `Das gewählte Startdatum ist vor dem kleinstmöglichen Startdatum ${minDatePropText}`;
     }
     if (startDate > maxDateProp.value) {
-      const maxDatePropText = maxDateProp.value.toLocaleDateString("de-DE", options);
+      const maxDatePropText = maxDateProp.value.toLocaleDateString(
+        "de-DE",
+        options
+      );
       return `Das gewählte Startdatum ist nach dem höchstmöglichen Enddatum ${maxDatePropText}`;
     }
   }
@@ -178,11 +193,17 @@ function validateTextDate(dateRangeToCheck: string): string | boolean {
   const endDate = new Date(endDateText);
   if (isEndDateValid) {
     if (endDate < minDateProp.value) {
-      const minDatePropText = minDateProp.value.toLocaleDateString("de-DE", options);
+      const minDatePropText = minDateProp.value.toLocaleDateString(
+        "de-DE",
+        options
+      );
       return `Das gewählte Enddatum ist vor dem kleinstmöglichen Startdatum ${minDatePropText}`;
     }
     if (endDate > maxDateProp.value) {
-      const maxDatePropText = maxDateProp.value.toLocaleDateString("de-DE", options);
+      const maxDatePropText = maxDateProp.value.toLocaleDateString(
+        "de-DE",
+        options
+      );
       return `Das gewählte Enddatum ist nach dem höchstmöglichen Enddatum ${maxDatePropText}`;
     }
   }

--- a/frontend/src/components/common/DateRangePicker.vue
+++ b/frontend/src/components/common/DateRangePicker.vue
@@ -16,8 +16,7 @@
         :disabled="props.disabled"
         :required="props.required"
         :clearable="false"
-        :min-date="minDateProp"
-        :max-date="maxDateProp"
+
         :week-numbers="WEEN_NUMBER_OPTIONS"
         :six-weeks="SIX_WEEK_CALENDAR_OPTIONS"
         cancel-text="Abbrechen"
@@ -64,6 +63,7 @@ import VueDatePicker from "@vuepic/vue-datepicker";
 import "@vuepic/vue-datepicker/dist/main.css";
 import _ from "lodash";
 import {computed, ref} from "vue";
+import {useDateUtils} from "@/util/DateUtils";
 
 interface Props {
   label?: string; // Bezeichnung des Datumsfelds
@@ -156,12 +156,14 @@ const format = (dateRange: Array<Date>) => {
   return dateRangeText;
 };
 
+const dateUtils = useDateUtils();
 function validateTextDate(dateRangeToCheck: string): string | boolean {
   const startAndEndDate = _.split(dateRangeToCheck, "-").map(date => date.trim());
 
-  const startDateText =  _.toString(_.head(startAndEndDate));
+  let startDateText =  _.toString(_.head(startAndEndDate));
+  startDateText = dateUtils.formatDateAsStringToISO(startDateText);
   const startDate = new Date(startDateText);
-  if (!_.isEmpty(startDate) && !isNaN(startDate.valueOf())) {
+  if (startDateText != "unbekannt" && !_.isEmpty(startDateText) && !isNaN(startDate.valueOf())) {
     if (startDate < minDateProp.value) {
       const minDatePropText = minDateProp.value.toLocaleDateString("de-DE", options);
       return `Das gewählte Startdatum ist vor dem kleinstmöglichen Startdatum ${minDatePropText}`
@@ -172,9 +174,10 @@ function validateTextDate(dateRangeToCheck: string): string | boolean {
     }
   }
 
-  const endDateText = _.toString(_.last(startAndEndDate));
+  let endDateText = _.toString(_.last(startAndEndDate));
+  endDateText = dateUtils.formatDateAsStringToISO(endDateText);
   const endDate = new Date(endDateText);
-  if (!_.isEmpty(endDateText) && !isNaN(endDate.valueOf())) {
+  if (endDateText != "unbekannt" && !_.isEmpty(endDateText) && !isNaN(endDate.valueOf())) {
     if (endDate < minDateProp.value) {
       const minDatePropText = minDateProp.value.toLocaleDateString("de-DE", options);
       return `Das gewählte Enddatum ist vor dem kleinstmöglichen Startdatum ${minDatePropText}`

--- a/frontend/src/components/messstelle/optionsmenue/OptionsmenueMessstelle.vue
+++ b/frontend/src/components/messstelle/optionsmenue/OptionsmenueMessstelle.vue
@@ -112,9 +112,9 @@ const messstelle = computed<MessstelleInfoDTO>(() => {
 
 const getContentSheetHeight = computed(() => {
   if (display.xl.value) {
-    return "650px";
+    return "800px";
   }
-  return "400px";
+  return "550px";
 });
 
 const isAnwender = computed(() => {

--- a/frontend/src/components/messstelle/optionsmenue/OptionsmenueMessstelle.vue
+++ b/frontend/src/components/messstelle/optionsmenue/OptionsmenueMessstelle.vue
@@ -112,9 +112,9 @@ const messstelle = computed<MessstelleInfoDTO>(() => {
 
 const getContentSheetHeight = computed(() => {
   if (display.xl.value) {
-    return "800px";
+    return "850px";
   }
-  return "550px";
+  return "600px";
 });
 
 const isAnwender = computed(() => {

--- a/frontend/src/components/messstelle/optionsmenue/OptionsmenueMessstelle.vue
+++ b/frontend/src/components/messstelle/optionsmenue/OptionsmenueMessstelle.vue
@@ -112,9 +112,9 @@ const messstelle = computed<MessstelleInfoDTO>(() => {
 
 const getContentSheetHeight = computed(() => {
   if (display.xl.value) {
-    return "850px";
+    return "750";
   }
-  return "600px";
+  return "500";
 });
 
 const isAnwender = computed(() => {

--- a/frontend/src/components/messstelle/optionsmenue/OptionsmenueMessstelle.vue
+++ b/frontend/src/components/messstelle/optionsmenue/OptionsmenueMessstelle.vue
@@ -112,9 +112,9 @@ const messstelle = computed<MessstelleInfoDTO>(() => {
 
 const getContentSheetHeight = computed(() => {
   if (display.xl.value) {
-    return "750";
+    return "750px";
   }
-  return "500";
+  return "500px";
 });
 
 const isAnwender = computed(() => {

--- a/frontend/src/components/messstelle/optionsmenue/panels/ZeitPanel.vue
+++ b/frontend/src/components/messstelle/optionsmenue/panels/ZeitPanel.vue
@@ -30,7 +30,7 @@
                 label="Datumsauswahl"
               />
             </v-col>
-            <v-col cols="6"/>
+            <v-col cols="6" />
           </v-row>
         </v-col>
         <v-col cols="4">
@@ -78,6 +78,7 @@ import type MessstelleInfoDTO from "@/types/messstelle/MessstelleInfoDTO";
 import type MessstelleOptionsDTO from "@/types/messstelle/MessstelleOptionsDTO";
 import type NichtPlausibleTageDTO from "@/types/messstelle/NichtPlausibleTageDTO";
 
+import _ from "lodash";
 import { computed, onMounted, ref, watch } from "vue";
 import { useRoute } from "vue-router";
 
@@ -92,7 +93,6 @@ import { useMessstelleStore } from "@/store/MessstelleStore";
 import { useUserStore } from "@/store/UserStore";
 import { useDateUtils } from "@/util/DateUtils";
 import { useOptionsmenuUtils } from "@/util/OptionsmenuUtils";
-import _ from "lodash";
 
 const route = useRoute();
 
@@ -135,7 +135,10 @@ const isAnwender = computed(() => {
 const minDate = computed(() => {
   const startdatum = new Date("2006-01-01");
   const realisierungsdatum = new Date(messstelleInfo.value.realisierungsdatum);
-  if (!_.isNil(messstelleInfo.value.realisierungsdatum) && realisierungsdatum >= startdatum)
+  if (
+    !_.isNil(messstelleInfo.value.realisierungsdatum) &&
+    realisierungsdatum >= startdatum
+  )
     return realisierungsdatum;
   else return startdatum;
 });
@@ -143,21 +146,24 @@ const minDate = computed(() => {
 const maxDate = computed(() => {
   const yesterday = new Date(new Date().setDate(new Date().getDate() - 1));
   return _.isNil(messstelleInfo.value.abbaudatum)
-      ? yesterday
-      : new Date(messstelleInfo.value.abbaudatum);
+    ? yesterday
+    : new Date(messstelleInfo.value.abbaudatum);
 });
 
 const zeitraum = computed({
   get() {
-    return _.toArray(chosenOptionsCopy.value.zeitraum).map(date => new Date(date));
+    return _.toArray(chosenOptionsCopy.value.zeitraum).map(
+      (date) => new Date(date)
+    );
   },
 
   set(dates: Array<Date> | undefined) {
-    const newZeitraum = _.toArray(dates).map(date => dateUtils.formatDateToISO(date))
+    const newZeitraum = _.toArray(dates).map((date) =>
+      dateUtils.formatDateToISO(date)
+    );
     chosenOptionsCopy.value.zeitraum = newZeitraum;
-  }
+  },
 });
-
 
 watch([chosenOptionsCopyWochentag, chosenOptionsCopyZeitraum], () => {
   if (

--- a/frontend/src/components/messstelle/optionsmenue/panels/ZeitPanel.vue
+++ b/frontend/src/components/messstelle/optionsmenue/panels/ZeitPanel.vue
@@ -34,12 +34,12 @@
           </v-row>
         </v-col>
         <v-col cols="4">
-          <div v-if="isAnwender || needRange">
+          <div v-if="isAnwender || isDateRange">
             <p>Hinweise:</p>
             <p v-if="isAnwender">
               Als Anwender beträgt der maximal mögliche Auswahlzeitraum 5 Jahre.
             </p>
-            <p v-if="needRange">
+            <p v-if="isDateRange">
               Alle Auswertungen stellen Durchschnittswerte des ausgewählten
               Zeitraums dar.
             </p>
@@ -49,11 +49,11 @@
       <v-divider />
 
       <tages-typ-radiogroup
-        v-if="needRange"
+        v-if="isDateRange"
         v-model="chosenOptionsCopy"
         :is-chosen-tages-typ-valid="isChosenTagesTypValid"
       />
-      <v-divider v-if="needRange" />
+      <v-divider v-if="isDateRange" />
 
       <zeitauswahl-radiogroup
         v-model="chosenOptionsCopy"
@@ -104,7 +104,7 @@ const userStore = useUserStore();
 const dateUtils = useDateUtils();
 const isChosenTagesTypValid = ref(true);
 
-const needRange = computed(() => {
+const isDateRange = computed(() => {
   const startDate = _.head(chosenOptionsCopy.value.zeitraum);
   const isValidStartDate = moment(startDate, "YYYY-MM-DD", true).isValid();
   const endDate = _.last(chosenOptionsCopy.value.zeitraum);

--- a/frontend/src/components/messstelle/optionsmenue/panels/ZeitPanel.vue
+++ b/frontend/src/components/messstelle/optionsmenue/panels/ZeitPanel.vue
@@ -78,7 +78,7 @@ import type MessstelleInfoDTO from "@/types/messstelle/MessstelleInfoDTO";
 import type MessstelleOptionsDTO from "@/types/messstelle/MessstelleOptionsDTO";
 import type NichtPlausibleTageDTO from "@/types/messstelle/NichtPlausibleTageDTO";
 
-import _ from "lodash";
+import { head, isEqual, isNil, last, toArray } from "lodash";
 import moment from "moment/moment";
 import { computed, onMounted, ref, watch } from "vue";
 import { useRoute } from "vue-router";
@@ -105,11 +105,11 @@ const dateUtils = useDateUtils();
 const isChosenTagesTypValid = ref(true);
 
 const isDateRange = computed(() => {
-  const startDate = _.head(chosenOptionsCopy.value.zeitraum);
+  const startDate = head(chosenOptionsCopy.value.zeitraum);
   const isValidStartDate = moment(startDate, "YYYY-MM-DD", true).isValid();
-  const endDate = _.last(chosenOptionsCopy.value.zeitraum);
+  const endDate = last(chosenOptionsCopy.value.zeitraum);
   const isValidEndDate = moment(endDate, "YYYY-MM-DD", true).isValid();
-  return isValidStartDate && isValidEndDate && !_.isEqual(startDate, endDate);
+  return isValidStartDate && isValidEndDate && !isEqual(startDate, endDate);
 });
 
 onMounted(() => {
@@ -144,7 +144,7 @@ const minDate = computed(() => {
   const startdatum = new Date("2006-01-01");
   const realisierungsdatum = new Date(messstelleInfo.value.realisierungsdatum);
   if (
-    !_.isNil(messstelleInfo.value.realisierungsdatum) &&
+    !isNil(messstelleInfo.value.realisierungsdatum) &&
     realisierungsdatum >= startdatum
   )
     return realisierungsdatum;
@@ -153,20 +153,20 @@ const minDate = computed(() => {
 
 const maxDate = computed(() => {
   const yesterday = new Date(new Date().setDate(new Date().getDate() - 1));
-  return _.isNil(messstelleInfo.value.abbaudatum)
+  return isNil(messstelleInfo.value.abbaudatum)
     ? yesterday
     : new Date(messstelleInfo.value.abbaudatum);
 });
 
 const zeitraum = computed({
   get() {
-    return _.toArray(chosenOptionsCopy.value.zeitraum).map(
+    return toArray(chosenOptionsCopy.value.zeitraum).map(
       (date) => new Date(date)
     );
   },
 
   set(dates: Array<Date> | undefined) {
-    const newZeitraum = _.toArray(dates).map((date) =>
+    const newZeitraum = toArray(dates).map((date) =>
       dateUtils.formatDateToISO(date)
     );
     chosenOptionsCopy.value.zeitraum = newZeitraum;

--- a/frontend/src/components/messstelle/optionsmenue/panels/ZeitPanel.vue
+++ b/frontend/src/components/messstelle/optionsmenue/panels/ZeitPanel.vue
@@ -133,16 +133,18 @@ const isAnwender = computed(() => {
 });
 
 const minDate = computed(() => {
-  if (messstelleInfo.value.realisierungsdatum >= "2006-01-01")
-    return messstelleInfo.value.realisierungsdatum;
-  else return "2006-01-01";
+  const startdatum = new Date("2006-01-01");
+  const realisierungsdatum = new Date(messstelleInfo.value.realisierungsdatum);
+  if (!_.isNil(messstelleInfo.value.realisierungsdatum) && realisierungsdatum >= startdatum)
+    return realisierungsdatum;
+  else return startdatum;
 });
 
 const maxDate = computed(() => {
-  const yesterday = new Date(new Date().setDate(new Date().getDate() - 1))
-    .toISOString()
-    .slice(0, 10);
-  return messstelleInfo.value.abbaudatum ?? yesterday;
+  const yesterday = new Date(new Date().setDate(new Date().getDate() - 1));
+  return _.isNil(messstelleInfo.value.abbaudatum)
+      ? yesterday
+      : new Date(messstelleInfo.value.abbaudatum);
 });
 
 const zeitraum = computed({

--- a/frontend/src/components/messstelle/optionsmenue/panels/ZeitPanel.vue
+++ b/frontend/src/components/messstelle/optionsmenue/panels/ZeitPanel.vue
@@ -79,6 +79,7 @@ import type MessstelleOptionsDTO from "@/types/messstelle/MessstelleOptionsDTO";
 import type NichtPlausibleTageDTO from "@/types/messstelle/NichtPlausibleTageDTO";
 
 import _ from "lodash";
+import moment from "moment/moment";
 import { computed, onMounted, ref, watch } from "vue";
 import { useRoute } from "vue-router";
 
@@ -102,7 +103,14 @@ const messstelleStore = useMessstelleStore();
 const userStore = useUserStore();
 const dateUtils = useDateUtils();
 const isChosenTagesTypValid = ref(true);
-const needRange = ref(chosenOptionsCopy.value.zeitraum.length > 1);
+
+const needRange = computed(() => {
+  const startDate = _.head(chosenOptionsCopy.value.zeitraum);
+  const isValidStartDate = moment(startDate, "YYYY-MM-DD", true).isValid();
+  const endDate = _.last(chosenOptionsCopy.value.zeitraum);
+  const isValidEndDate = moment(endDate, "YYYY-MM-DD", true).isValid();
+  return isValidStartDate && isValidEndDate && !_.isEqual(startDate, endDate);
+});
 
 onMounted(() => {
   const messstelleId = route.params.messstelleId as string;

--- a/frontend/src/components/zaehlstelle/optionsmenue/OptionsmenueZaehlstelle.vue
+++ b/frontend/src/components/zaehlstelle/optionsmenue/OptionsmenueZaehlstelle.vue
@@ -162,9 +162,9 @@ const options = computed<OptionsDTO>(() => {
 
 const getContentSheetHeight = computed(() => {
   if (display.xl.value) {
-    return "650px";
+    return "850px";
   }
-  return "400px";
+  return "600px";
 });
 
 /**

--- a/frontend/src/components/zaehlstelle/optionsmenue/OptionsmenueZaehlstelle.vue
+++ b/frontend/src/components/zaehlstelle/optionsmenue/OptionsmenueZaehlstelle.vue
@@ -162,9 +162,9 @@ const options = computed<OptionsDTO>(() => {
 
 const getContentSheetHeight = computed(() => {
   if (display.xl.value) {
-    return "850px";
+    return "750px";
   }
-  return "600px";
+  return "500px";
 });
 
 /**


### PR DESCRIPTION
**Description**

Austausch des Custom-Date-Picker bestehend aus Vuetify-Komponenten durch [vue3datepicker](https://github.com/Vuepic/vue-datepicker).

Die beide Felder für die Datumswerte `von` und `bis` sind durch die Range-Picker-Funktionalität von  `vue3datepicker` ersetzt worden.

**Reference**

DAVE-418
