### PR TITLE
DAVE-471 Auswahl Spitzenstunde auch bei nur einen selektierten Messquerschnitt

### DIFF
--- a/apigateway/pom.xml
+++ b/apigateway/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.release>${java.version}</maven.compiler.release>
-        <spring.boot.version>3.4.2</spring.boot.version>
+        <spring.boot.version>3.4.3</spring.boot.version>
         <spring.cloud.version>2024.0.0</spring.cloud.version>
         <!-- Version muss mit der in den spring-boot-dependencies bereitgestellten Lombok-Version übereinstimmen -->
         <org.projectlombok.lombok.version>1.18.36</org.projectlombok.lombok.version>

--- a/frontend/src/components/messstelle/optionsmenue/panels/MessquerschnittPanel.vue
+++ b/frontend/src/components/messstelle/optionsmenue/panels/MessquerschnittPanel.vue
@@ -89,8 +89,6 @@ const messstelleUtils = useMessstelleUtils();
 
 const MIND_EIN_MESSQUERSCHNITT =
   "Es muss mindestens ein Messquerschnitt ausgewählt sein.";
-const GENAU_EIN_MESSQUERSCHNITT =
-  "Es muss genau ein Messquerschnitt ausgewählt sein.";
 
 const messstelle = computed<MessstelleInfoDTO>(() => {
   return messstelleStore.getMessstelleInfo;

--- a/frontend/src/components/messstelle/optionsmenue/panels/MessquerschnittPanel.vue
+++ b/frontend/src/components/messstelle/optionsmenue/panels/MessquerschnittPanel.vue
@@ -70,7 +70,7 @@ import type MessquerschnittInfoDTO from "@/types/messstelle/MessquerschnittInfoD
 import type MessstelleInfoDTO from "@/types/messstelle/MessstelleInfoDTO";
 import type MessstelleOptionsDTO from "@/types/messstelle/MessstelleOptionsDTO";
 
-import _ from "lodash";
+import { cloneDeep } from "lodash";
 import { computed, ref, watch } from "vue";
 
 import PanelHeader from "@/components/common/PanelHeader.vue";
@@ -206,7 +206,7 @@ function updateOptions() {
     chosenOptionsCopy.value.messquerschnittIds.push(value.value)
   );
 
-  previousSelectedStructures.value = _.cloneDeep(
+  previousSelectedStructures.value = cloneDeep(
     chosenOptionsCopy.value.messquerschnittIds
   );
 }

--- a/frontend/src/components/messstelle/optionsmenue/panels/MessquerschnittPanel.vue
+++ b/frontend/src/components/messstelle/optionsmenue/panels/MessquerschnittPanel.vue
@@ -48,7 +48,6 @@
             :rules="[REQUIRED]"
             density="compact"
             @update:model-value="updateLage"
-            @blur="resetSpitzenstundeErrorText"
             @mouseover="hoverLage = true"
             @mouseleave="hoverLage = false"
           />
@@ -57,9 +56,6 @@
         <v-col cols="4">
           <v-card flat>
             <div v-if="hoverLage">{{ helpTextLageHover }}</div>
-            <div v-if="spitzenstundeErrorText.length > 0">
-              {{ spitzenstundeErrorText }}
-            </div>
             <div>{{ helpTextLage }}</div>
           </v-card>
         </v-col>
@@ -88,7 +84,6 @@ const chosenOptionsCopy = defineModel<MessstelleOptionsDTO>({ required: true });
 
 const hoverDirection = ref(false);
 const hoverLage = ref(false);
-const spitzenstundeErrorText = ref("");
 const messstelleStore = useMessstelleStore();
 const messstelleUtils = useMessstelleUtils();
 
@@ -116,10 +111,7 @@ const direction = computed({
 const richtungValues = computed<Array<KeyVal>>(() => {
   const result: Array<KeyVal> = [];
   const exisitingDirection: Array<Himmelsrichtungen> = [];
-  if (
-    messstelle.value.messquerschnitte.length > 1 &&
-    !isZeitauswahlSpitzenstunde.value
-  ) {
+  if (messstelle.value.messquerschnitte.length > 1) {
     result.push({
       title: messstelleUtils.alleRichtungen,
       value: messstelleUtils.alleRichtungen,
@@ -181,11 +173,6 @@ const helpTextLage = computed(() => {
   if (direction.value === messstelleUtils.alleRichtungen) {
     text =
       "Hinweis: Um einzelne Messquerschnitte auszuwählen, muss zuvor eine Richtung bestimmt werden.";
-  } else if (
-    isZeitauswahlSpitzenstunde.value &&
-    chosenOptionsCopy.value.messquerschnittIds.length !== 1
-  ) {
-    text = GENAU_EIN_MESSQUERSCHNITT;
   } else if (chosenOptionsCopy.value.messquerschnittIds.length === 0) {
     text = MIND_EIN_MESSQUERSCHNITT;
   }
@@ -203,11 +190,6 @@ const helpTextLageHover = computed(() => {
   return text;
 });
 
-const isZeitauswahlSpitzenstunde = computed(() => {
-  return messstelleUtils.isZeitauswahlSpitzenstunde(
-    chosenOptionsCopy.value.zeitauswahl
-  );
-});
 const zeitauswahl = computed(() => {
   return chosenOptionsCopy.value.zeitauswahl;
 });
@@ -217,60 +199,26 @@ const previousSelectedStructures = ref<Array<string>>(
 );
 
 watch(zeitauswahl, () => {
-  if (
-    isZeitauswahlSpitzenstunde.value &&
-    chosenOptionsCopy.value.messquerschnittIds.length > 1
-  ) {
-    chosenOptionsCopy.value.messquerschnittIds = [];
-  }
   previousSelectedStructures.value = chosenOptionsCopy.value.messquerschnittIds;
 });
 
 function updateOptions() {
   chosenOptionsCopy.value.messquerschnittIds = [];
-  if (isZeitauswahlSpitzenstunde.value) {
-    const firstLageValue = lageValues.value.at(0);
-    if (firstLageValue) {
-      chosenOptionsCopy.value.messquerschnittIds.push(firstLageValue.value);
-    }
-  } else {
-    lageValues.value.forEach((value) =>
-      chosenOptionsCopy.value.messquerschnittIds.push(value.value)
-    );
-  }
+  lageValues.value.forEach((value) =>
+    chosenOptionsCopy.value.messquerschnittIds.push(value.value)
+  );
+
   previousSelectedStructures.value = _.cloneDeep(
     chosenOptionsCopy.value.messquerschnittIds
   );
-  resetSpitzenstundeErrorText();
 }
 
 function updateLage(lageValue: Array<string>) {
-  resetSpitzenstundeErrorText();
-  if (isZeitauswahlSpitzenstunde.value) {
-    if (chosenOptionsCopy.value.messquerschnittIds.length === 2) {
-      spitzenstundeErrorText.value =
-        "Zur Berechnung der Spitzenstunde muss genau ein Messquerschnitt ausgewählt sein.";
-    }
-    chosenOptionsCopy.value.messquerschnittIds = lageValue.filter(
-      (val) => !previousSelectedStructures.value.includes(val)
-    );
-    previousSelectedStructures.value = _.cloneDeep(
-      chosenOptionsCopy.value.messquerschnittIds
-    );
-  } else {
-    previousSelectedStructures.value = lageValue;
-  }
+  previousSelectedStructures.value = lageValue;
 }
 
 function REQUIRED(v: Array<string>) {
   if (v.length > 0) return true;
-  let errortext = MIND_EIN_MESSQUERSCHNITT;
-  if (isZeitauswahlSpitzenstunde.value) {
-    errortext = GENAU_EIN_MESSQUERSCHNITT;
-  }
-  return errortext;
-}
-function resetSpitzenstundeErrorText(): void {
-  spitzenstundeErrorText.value = "";
+  return MIND_EIN_MESSQUERSCHNITT;
 }
 </script>

--- a/frontend/src/components/messstelle/optionsmenue/panels/ZeitauswahlRadiogroup.vue
+++ b/frontend/src/components/messstelle/optionsmenue/panels/ZeitauswahlRadiogroup.vue
@@ -177,7 +177,7 @@ function zeitauswahlChanged() {
 }
 
 watch(
-  () => chosenOptionsCopy.value.zeitraum,
+  () => isZeitraumGreaterThanFiveYears.value,
   () => {
     if (
       isZeitraumGreaterThanFiveYears.value &&

--- a/frontend/src/components/messstelle/optionsmenue/panels/ZeitauswahlRadiogroup.vue
+++ b/frontend/src/components/messstelle/optionsmenue/panels/ZeitauswahlRadiogroup.vue
@@ -72,7 +72,7 @@
           justify="center"
           dense
         >
-          {{ helperText }}
+          {{ helpText }}
         </v-row>
       </v-col>
     </v-row>
@@ -122,15 +122,12 @@ const durchschnitt = computed(() => {
 });
 
 function isTypeDisabled(type: string): boolean {
-  return (
-    type !== props.messstelleDetektierteFahrzeugart ||
-    chosenOptionsCopy.value.messquerschnittIds.length !== 1
-  );
+  return type !== props.messstelleDetektierteFahrzeugart;
 }
 
-const helperText = computed(() => {
-  if (chosenOptionsCopy.value.messquerschnittIds.length !== 1) {
-    return "Spitzenstunde kann nur für einen einzelnen Messquerschnitt ausgegeben werden";
+const helpText = computed(() => {
+  if (isZeitraumGreaterThanFiveYears.value) {
+    return "Die Spitzenstunde kann nur für Zeiträume kleiner 5 Jahre angezeigt werden";
   }
   return "";
 });
@@ -189,6 +186,7 @@ watch(
       chosenOptionsCopy.value.zeitauswahl = Zeitauswahl.TAGESWERT;
       snackbarStore.showInfo("Zeitauswahl wurde auf Tageswert gesetzt");
     }
-  }
+  },
+  { immediate: true, deep: true }
 );
 </script>


### PR DESCRIPTION
Auch wenn nicht alle Messquerschnitte gewählt sind, kann die Spitzenstunde im Optionsmenü gewählt werden.

**Reference**

DAVE-471
