### PR TITLE
FV-266 Anzeige Belastungsplan für Messstelle fehlerhaft

### DIFF
--- a/frontend/src/components/messstelle/MessstelleGeometrie.vue
+++ b/frontend/src/components/messstelle/MessstelleGeometrie.vue
@@ -100,7 +100,7 @@ function drawArrowsPointingSouth() {
       )
       .stroke({
         width: strokeSize,
-        color: calculateColor(Himmelsrichtung.SUED, Himmelsrichtung.WEST),
+        color: calculateColor(Himmelsrichtung.S, Himmelsrichtung.W),
       })
   );
   querschnittGroup.value.add(
@@ -112,9 +112,9 @@ function drawArrowsPointingSouth() {
       )
       .stroke({
         width: strokeSize,
-        color: calculateColor(Himmelsrichtung.SUED, Himmelsrichtung.WEST),
+        color: calculateColor(Himmelsrichtung.S, Himmelsrichtung.W),
       })
-      .attr("fill", calculateColor(Himmelsrichtung.SUED, Himmelsrichtung.WEST))
+      .attr("fill", calculateColor(Himmelsrichtung.S, Himmelsrichtung.W))
   );
   startX.value += 50;
 }
@@ -130,7 +130,7 @@ function drawArrowsPointingNorth() {
       )
       .stroke({
         width: strokeSize,
-        color: calculateColor(Himmelsrichtung.OST, Himmelsrichtung.NORD),
+        color: calculateColor(Himmelsrichtung.O, Himmelsrichtung.N),
       })
   );
   querschnittGroup.value.add(
@@ -142,16 +142,16 @@ function drawArrowsPointingNorth() {
       )
       .stroke({
         width: strokeSize,
-        color: calculateColor(Himmelsrichtung.OST, Himmelsrichtung.NORD),
+        color: calculateColor(Himmelsrichtung.O, Himmelsrichtung.N),
       })
-      .attr("fill", calculateColor(Himmelsrichtung.OST, Himmelsrichtung.NORD))
+      .attr("fill", calculateColor(Himmelsrichtung.O, Himmelsrichtung.N))
   );
   startX.value += 50;
 }
 
 function rotateArrowsIfNecessary() {
   const direction = props.messquerschnitte[0]?.fahrtrichtung;
-  if (direction === Himmelsrichtung.OST || direction === Himmelsrichtung.WEST) {
+  if (direction === Himmelsrichtung.O || direction === Himmelsrichtung.W) {
     querschnittGroup.value.rotate(90).translate(100, -50);
   }
 }

--- a/frontend/src/components/messstelle/charts/BelastungsplanMessquerschnittCard.vue
+++ b/frontend/src/components/messstelle/charts/BelastungsplanMessquerschnittCard.vue
@@ -43,10 +43,10 @@ const defaultFontSize = 24;
 const sheetId = "belastungsplan-messquerschnitt";
 
 const farben = new Map<string, string>([
-  [Himmelsrichtung.NORD, "#4CAF50"],
-  [Himmelsrichtung.OST, "#2196F3"],
-  [Himmelsrichtung.SUED, "#000000"],
-  [Himmelsrichtung.WEST, "#F44336"],
+  [Himmelsrichtung.N, "#4CAF50"],
+  [Himmelsrichtung.O, "#2196F3"],
+  [Himmelsrichtung.S, "#000000"],
+  [Himmelsrichtung.W, "#F44336"],
 ]);
 
 const maxVerhiclesPerMq = ref(0);
@@ -158,8 +158,7 @@ function drawArrowsPointingSouth(
 ) {
   const arrayOfDataForDirectionSouth = groupedByDirection.find(
     (obj) =>
-      obj.direction === Himmelsrichtung.SUED ||
-      obj.direction === Himmelsrichtung.WEST
+      obj.direction === Himmelsrichtung.S || obj.direction === Himmelsrichtung.W
   );
   arrayOfDataForDirectionSouth?.data.forEach((mq) => {
     querschnittGroup.value.add(
@@ -302,8 +301,7 @@ function drawArrowsPointingNorth(
 ) {
   const arrayOfDataForDirectionNorth = groupedByDirection.find(
     (obj) =>
-      obj.direction === Himmelsrichtung.NORD ||
-      obj.direction === Himmelsrichtung.OST
+      obj.direction === Himmelsrichtung.N || obj.direction === Himmelsrichtung.O
   );
   arrayOfDataForDirectionNorth?.data.forEach((mq) => {
     querschnittGroup.value.add(
@@ -400,7 +398,7 @@ function rotateArrowsIfNecessary() {
   const direction =
     props.belastungsplanData.ladeBelastungsplanMessquerschnittDataDTOList[0]
       .direction;
-  if (direction === Himmelsrichtung.OST || direction === Himmelsrichtung.WEST) {
+  if (direction === Himmelsrichtung.O || direction === Himmelsrichtung.W) {
     querschnittGroup.value.rotate(90).translate(100, -50);
   }
 }

--- a/frontend/src/components/messstelle/charts/BelastungsplanMqSchematischeUebersicht.vue
+++ b/frontend/src/components/messstelle/charts/BelastungsplanMqSchematischeUebersicht.vue
@@ -156,8 +156,7 @@ function drawArrowsPointingSouth(
 ) {
   const arrayOfDataForDirectionSouth = groupedByDirection.find(
     (obj) =>
-      obj.direction === Himmelsrichtung.SUED ||
-      obj.direction === Himmelsrichtung.WEST
+      obj.direction === Himmelsrichtung.S || obj.direction === Himmelsrichtung.W
   );
   arrayOfDataForDirectionSouth?.data.forEach((mq) => {
     querschnittGroup.value.add(
@@ -195,8 +194,7 @@ function drawArrowsPointingNorth(
 ) {
   const arrayOfDataForDirectionNorth = groupedByDirection.find(
     (obj) =>
-      obj.direction === Himmelsrichtung.NORD ||
-      obj.direction === Himmelsrichtung.OST
+      obj.direction === Himmelsrichtung.N || obj.direction === Himmelsrichtung.O
   );
   arrayOfDataForDirectionNorth?.data.forEach((mq) => {
     querschnittGroup.value.add(
@@ -230,7 +228,7 @@ function rotateArrowsIfNecessary() {
   const direction =
     props.belastungsplanData.ladeBelastungsplanMessquerschnittDataDTOList[0]
       .direction;
-  if (direction === Himmelsrichtung.OST || direction === Himmelsrichtung.WEST) {
+  if (direction === Himmelsrichtung.O || direction === Himmelsrichtung.W) {
     querschnittGroup.value.rotate(90).translate(100, -50);
   }
 }

--- a/frontend/src/components/messstelle/icons/FahrtrichtungIcon.vue
+++ b/frontend/src/components/messstelle/icons/FahrtrichtungIcon.vue
@@ -44,19 +44,19 @@ const icon = computed<IconTooltip>(() => {
 function himmelsrichtungIcons(): Map<string, IconTooltip> {
   return new Map([
     [
-      Himmelsrichtung.NORD,
+      Himmelsrichtung.N,
       new IconTooltip("mdi-arrow-up-thin-circle-outline", "Nord"),
     ],
     [
-      Himmelsrichtung.SUED,
+      Himmelsrichtung.S,
       new IconTooltip("mdi-arrow-down-thin-circle-outline", "Süd"),
     ],
     [
-      Himmelsrichtung.OST,
+      Himmelsrichtung.O,
       new IconTooltip("mdi-arrow-right-thin-circle-outline", "Ost"),
     ],
     [
-      Himmelsrichtung.WEST,
+      Himmelsrichtung.W,
       new IconTooltip("mdi-arrow-left-thin-circle-outline", "West"),
     ],
   ]);


### PR DESCRIPTION
# Description

Durch die Verwendung der korrekten Himmeslrichtung wird der Belastungsplan nun wieder angezeigt.

# Issue References

<!-- Add the corresponding issues here -->
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [ ] Acceptance criteria are met
- [ ] Testing is done (unit-tests, DEV-environment)
- [ ] Build/Test workflow has successfully finished
- [ ] Release notes are complemented
- [ ] Documentation is complemented (operator manual, system specification, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized compass direction notation across arrow rendering, color mapping, and direction-based icon display components to improve code consistency and maintainability throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->