### PR TITLE
FV-262 Filtermenue Zaehlungsvergleich Zeitreihe

### DIFF
--- a/frontend/src/components/zaehlstelle/optionsmenue/panels/ZaehlungsvergleichPanel.vue
+++ b/frontend/src/components/zaehlstelle/optionsmenue/panels/ZaehlungsvergleichPanel.vue
@@ -93,16 +93,17 @@
 <script setup lang="ts">
 import type KeyVal from "@/types/common/KeyVal";
 import type LadeZaehlungDTO from "@/types/zaehlung/LadeZaehlungDTO";
+import type QuerungsverkehrDTO from "@/types/zaehlung/QuerungsverkehrDTO";
 import type ZaehlstelleOptionsDTO from "@/types/zaehlung/ZaehlstelleOptionsDTO";
+import type { ComputedRef } from "vue";
 
-import {computed, type ComputedRef, onMounted, ref, watch} from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 
 import PanelHeader from "@/components/common/PanelHeader.vue";
 import { useZaehlstelleStore } from "@/store/ZaehlstelleStore";
+import Zaehlart from "@/types/enum/Zaehlart";
 import Zeitauswahl from "@/types/enum/Zeitauswahl";
 import { useDateUtils } from "@/util/DateUtils";
-import Zaehlart from "@/types/enum/Zaehlart";
-import type QuerungsverkehrDTO from "@/types/zaehlung/QuerungsverkehrDTO";
 
 const chosenOptionsCopy = defineModel<ZaehlstelleOptionsDTO>({
   required: true,
@@ -159,11 +160,16 @@ const helpTextDifferenzdatenBelastungsplan = computed(() => {
     return "Für den Differenzdatenvergleich muss das Kontrollkästchen aktiviert werden.";
   }
   if (hoverSelectVergleichsdatumZeitreihe.value) {
-    return (
-        (["FJS", "QJS", "QU"].includes(activeZaehlung.value.zaehlart)
-            ? "Es können nur Zählungen gleicher Zählart und mit gleichen Verkehrsbeziehungen verglichen werden. Der Tageswert kann immer verglichen werden, ansonsten muss in den Vergleichszählungen der gewählten Zeitblock bzw. die gewählte Stunde vorhanden sein."
-            : "Es können nur Zählungen gleicher Zählart verglichen werden. Der Tageswert kann immer verglichen werden, ansonsten muss in den Vergleichszählungen der gewählten Zeitblock bzw. die gewählte Stunde vorhanden sein.")
-    );
+    const part: string =
+      "Der Tageswert kann immer verglichen werden, ansonsten muss in den Vergleichszählungen der gewählten Zeitblock bzw. die gewählte Stunde vorhanden sein.";
+    return [
+      Zaehlart.FJS.toString(),
+      Zaehlart.QJS.toString(),
+      Zaehlart.QU.toString(),
+    ].includes(activeZaehlung.value.zaehlart)
+      ? "Es können nur Zählungen gleicher Zählart und mit gleichen Verkehrsbeziehungen verglichen werden." +
+          part
+      : "Es können nur Zählungen gleicher Zählart verglichen werden." + part;
   }
   return "";
 });
@@ -213,7 +219,7 @@ function vergleichsdatumCalculator(): void {
  * - Welche älter als oder gleich alt wie die Basiszählung sind.
  * - Welche die selbe Zählart besitzt.
  * - Welche den gewählten Zeitblock besitzt.
- * - Bei QU, QJS, FJS: Welche übereinstimmende Bewegungsbeziehungen/Pfeilen besitzt.
+ * - Bei QU, QJS, FJS: Welche übereinstimmende Bewegungsbeziehungen/Pfeile besitzt.
  * */
 function zeitreihenVergleichsdatumCalculator(): void {
   const result: Array<KeyVal> = new Array<KeyVal>();
@@ -231,7 +237,7 @@ function zeitreihenVergleichsdatumCalculator(): void {
         (containsZeitblock(zaehl, chosenOptionsCopy.value.zeitblock) ||
           chosenOptionsCopy.value.zeitauswahl.toString() ===
             Zeitauswahl.TAGESWERT.toString()) &&
-          checkBewegungsbeziehungen(zaehl, activeZaehlung)
+        checkBewegungsbeziehungen(zaehl, activeZaehlung)
       ) {
         result.push({
           title: dateUtils.getShortVersionOfDate(
@@ -244,8 +250,12 @@ function zeitreihenVergleichsdatumCalculator(): void {
   }
   vergleichsdatumZeitreihe.value = result;
   // Setze idVergleichszaehlungZeitreihe zurück (auf null), wenn der Wert nicht im Array result enthalten ist
-  const selectedVergleichszaehlungId = chosenOptionsCopy.value.idVergleichszaehlungZeitreihe;
-  if (selectedVergleichszaehlungId != null && !result.some(item => item.value === selectedVergleichszaehlungId)) {
+  const selectedVergleichszaehlungId =
+    chosenOptionsCopy.value.idVergleichszaehlungZeitreihe;
+  if (
+    selectedVergleichszaehlungId != null &&
+    !result.some((item) => item.value === selectedVergleichszaehlungId)
+  ) {
     chosenOptionsCopy.value.idVergleichszaehlungZeitreihe = null;
   }
 }
@@ -257,36 +267,52 @@ function zeitreihenVergleichsdatumCalculator(): void {
  * @param zaehlung zu prüfende Zaehlung
  * @param activeZaehlung aktive Zaehlung
  */
-function checkBewegungsbeziehungen(zaehlung: LadeZaehlungDTO, activeZaehlung: ComputedRef<LadeZaehlungDTO>): boolean {
+function checkBewegungsbeziehungen(
+  zaehlung: LadeZaehlungDTO,
+  activeZaehlung: ComputedRef<LadeZaehlungDTO>
+): boolean {
   // Bei QU: Prüfe auf Knotenarm und Richtung
   if (zaehlung.zaehlart === Zaehlart.QU.toString()) {
-    return activeZaehlung.value.querungsverkehr.length === zaehlung.querungsverkehr.length &&
-        activeZaehlung.value.querungsverkehr.every(activeQv =>
-        zaehlung.querungsverkehr.some(qv =>
-            qv.knotenarm === activeQv.knotenarm && qv.richtung === activeQv.richtung
+    return (
+      activeZaehlung.value.querungsverkehr.length ===
+        zaehlung.querungsverkehr.length &&
+      activeZaehlung.value.querungsverkehr.every((activeQv) =>
+        zaehlung.querungsverkehr.some(
+          (qv) =>
+            qv.knotenarm === activeQv.knotenarm &&
+            qv.richtung === activeQv.richtung
         )
+      )
     );
   }
   // Bei FJS: Prüfe auf Knotenarm, Richtung und Straßenseite
   if (zaehlung.zaehlart === Zaehlart.FJS.toString()) {
-    return activeZaehlung.value.laengsverkehr.length === zaehlung.laengsverkehr.length &&
-        activeZaehlung.value.laengsverkehr.every(activeLv =>
-        zaehlung.laengsverkehr.some(lv =>
+    return (
+      activeZaehlung.value.laengsverkehr.length ===
+        zaehlung.laengsverkehr.length &&
+      activeZaehlung.value.laengsverkehr.every((activeLv) =>
+        zaehlung.laengsverkehr.some(
+          (lv) =>
             lv.knotenarm === activeLv.knotenarm &&
             lv.richtung === activeLv.richtung &&
             lv.strassenseite === activeLv.strassenseite
         )
+      )
     );
   }
   // Bei QJS: Prüfe auf Von, Nach und Straßenseite
   if (zaehlung.zaehlart === Zaehlart.QJS.toString()) {
-    return activeZaehlung.value.verkehrsbeziehungen.length === zaehlung.verkehrsbeziehungen.length &&
-        activeZaehlung.value.verkehrsbeziehungen.every(activeVb =>
-        zaehlung.verkehrsbeziehungen.some(qjs =>
+    return (
+      activeZaehlung.value.verkehrsbeziehungen.length ===
+        zaehlung.verkehrsbeziehungen.length &&
+      activeZaehlung.value.verkehrsbeziehungen.every((activeVb) =>
+        zaehlung.verkehrsbeziehungen.some(
+          (qjs) =>
             qjs.von === activeVb.von &&
             qjs.nach === activeVb.nach &&
             qjs.strassenseite === activeVb.strassenseite
         )
+      )
     );
   }
   return true; // Standard-Rückgabewert, wenn andere Zaehlart

--- a/frontend/src/components/zaehlstelle/optionsmenue/panels/ZaehlungsvergleichPanel.vue
+++ b/frontend/src/components/zaehlstelle/optionsmenue/panels/ZaehlungsvergleichPanel.vue
@@ -242,9 +242,9 @@ function zeitreihenVergleichsdatumCalculator(): void {
     });
   }
   vergleichsdatumZeitreihe.value = result;
-  // // Setze idVergleichszaehlungZeitreihe auf null, wenn der Wert nicht im Array vergleichsdatumZeitreihe enthalten ist
-  const isIdVergleichszaehlungInArray = vergleichsdatumZeitreihe.value.some(item => item.value === chosenOptionsCopy.value.idVergleichszaehlungZeitreihe);
-  if (!isIdVergleichszaehlungInArray) {
+  // Setze idVergleichszaehlungZeitreihe zurück (auf null), wenn der Wert nicht im Array result enthalten ist
+  const selectedVergleichszaehlungId = chosenOptionsCopy.value.idVergleichszaehlungZeitreihe;
+  if (selectedVergleichszaehlungId != null && !result.some(item => item.value === selectedVergleichszaehlungId)) {
     chosenOptionsCopy.value.idVergleichszaehlungZeitreihe = null;
   }
 }

--- a/frontend/src/components/zaehlstelle/optionsmenue/panels/ZaehlungsvergleichPanel.vue
+++ b/frontend/src/components/zaehlstelle/optionsmenue/panels/ZaehlungsvergleichPanel.vue
@@ -230,7 +230,7 @@ function zeitreihenVergleichsdatumCalculator(): void {
         (containsZeitblock(zaehl, chosenOptionsCopy.value.zeitblock) ||
           chosenOptionsCopy.value.zeitauswahl.toString() ===
             Zeitauswahl.TAGESWERT.toString()) &&
-          checkVerkehrsbeziehungen(zaehl, activeZaehlung)
+          checkVerkehrsbeziehungen(zaehl)
       ) {
         result.push({
           title: dateUtils.getShortVersionOfDate(
@@ -242,45 +242,48 @@ function zeitreihenVergleichsdatumCalculator(): void {
     });
   }
   vergleichsdatumZeitreihe.value = result;
+  // // Setze idVergleichszaehlungZeitreihe auf null, wenn der Wert nicht im Array vergleichsdatumZeitreihe enthalten ist
+  const isIdVergleichszaehlungInArray = vergleichsdatumZeitreihe.value.some(item => item.value === chosenOptionsCopy.value.idVergleichszaehlungZeitreihe);
+  if (!isIdVergleichszaehlungInArray) {
+    chosenOptionsCopy.value.idVergleichszaehlungZeitreihe = null;
+  }
 }
 
 /**
- * Prüfung bei Zählart QU, QJS oder FJS: Alle Verkehrsbeziehungen und Pfeile der aktiven Zählung müssen in der zu prüfenden Zählung vorhanden sein.
+ * Prüfung bei Zählart QU, QJS oder FJS: Alle Verkehrsbeziehungen und Pfeile der in den Optionen gewählten Zählung müssen in der zu prüfenden Zählung vorhanden sein.
  * Für alle anderen Verkehrsarten wird immer true zurückgegeben.
  *
  * @param zaehlung
- * @param activeZaehlung
  */
-function checkVerkehrsbeziehungen(zaehlung: LadeZaehlungDTO, activeZaehlung: ComputedRef<LadeZaehlungDTO>): boolean {
+function checkVerkehrsbeziehungen(zaehlung: LadeZaehlungDTO): boolean {
   // Bei QU: Prüfe auf Knotenarm und Richtung
   if (zaehlung.zaehlart === Zaehlart.QU.toString()) {
-    return activeZaehlung.value.querungsverkehr.every(activeQv =>
+    return chosenOptionsCopy.value.chosenQuerungsverkehre.every(chosenQv =>
         zaehlung.querungsverkehr.some(qv =>
-            qv.knotenarm === activeQv.knotenarm && qv.richtung === activeQv.richtung
+            qv.knotenarm === chosenQv.knotenarm && qv.richtung === chosenQv.richtung
         )
     );
   }
   // Bei FJS: Prüfe auf Knotenarm, Richtung und Straßenseite
   if (zaehlung.zaehlart === Zaehlart.FJS.toString()) {
-    return activeZaehlung.value.laengsverkehr.every(activeLv =>
+    return chosenOptionsCopy.value.chosenLaengsverkehre.every(ChosenLv =>
         zaehlung.laengsverkehr.some(lv =>
-            lv.knotenarm === activeLv.knotenarm &&
-            lv.richtung === activeLv.richtung &&
-            lv.strassenseite === activeLv.strassenseite
+            lv.knotenarm === ChosenLv.knotenarm &&
+            lv.richtung === ChosenLv.richtung &&
+            lv.strassenseite === ChosenLv.strassenseite
         )
     );
   }
   // Bei QJS: Prüfe auf Von, Nach und Straßenseite
   if (zaehlung.zaehlart === Zaehlart.QJS.toString()) {
-    return activeZaehlung.value.verkehrsbeziehungen.every(activeQjs =>
+    return chosenOptionsCopy.value.chosenVerkehrsbeziehungen.every(chosenVb =>
         zaehlung.verkehrsbeziehungen.some(qjs =>
-            qjs.von === activeQjs.von &&
-            qjs.nach === activeQjs.nach &&
-            qjs.strassenseite === activeQjs.strassenseite
+            qjs.von === chosenVb.von &&
+            qjs.nach === chosenVb.nach &&
+            qjs.strassenseite === chosenVb.strassenseite
         )
     );
   }
-
   return true; // Standard-Rückgabewert, wenn andere Zaehlart
 }
 

--- a/frontend/src/components/zaehlstelle/optionsmenue/panels/ZaehlungsvergleichPanel.vue
+++ b/frontend/src/components/zaehlstelle/optionsmenue/panels/ZaehlungsvergleichPanel.vue
@@ -95,12 +95,14 @@ import type KeyVal from "@/types/common/KeyVal";
 import type LadeZaehlungDTO from "@/types/zaehlung/LadeZaehlungDTO";
 import type ZaehlstelleOptionsDTO from "@/types/zaehlung/ZaehlstelleOptionsDTO";
 
-import { computed, onMounted, ref, watch } from "vue";
+import {computed, type ComputedRef, onMounted, ref, watch} from "vue";
 
 import PanelHeader from "@/components/common/PanelHeader.vue";
 import { useZaehlstelleStore } from "@/store/ZaehlstelleStore";
 import Zeitauswahl from "@/types/enum/Zeitauswahl";
 import { useDateUtils } from "@/util/DateUtils";
+import Zaehlart from "@/types/enum/Zaehlart";
+import type QuerungsverkehrDTO from "@/types/zaehlung/QuerungsverkehrDTO";
 
 const chosenOptionsCopy = defineModel<ZaehlstelleOptionsDTO>({
   required: true,
@@ -227,7 +229,8 @@ function zeitreihenVergleichsdatumCalculator(): void {
         zaehl.sonderzaehlung === activeZaehlung.value.sonderzaehlung &&
         (containsZeitblock(zaehl, chosenOptionsCopy.value.zeitblock) ||
           chosenOptionsCopy.value.zeitauswahl.toString() ===
-            Zeitauswahl.TAGESWERT.toString())
+            Zeitauswahl.TAGESWERT.toString()) &&
+          checkVerkehrsbeziehungen(zaehl, activeZaehlung)
       ) {
         result.push({
           title: dateUtils.getShortVersionOfDate(
@@ -239,6 +242,46 @@ function zeitreihenVergleichsdatumCalculator(): void {
     });
   }
   vergleichsdatumZeitreihe.value = result;
+}
+
+/**
+ * Prüfung bei Zählart QU, QJS oder FJS: Alle Verkehrsbeziehungen und Pfeile der aktiven Zählung müssen in der zu prüfenden Zählung vorhanden sein.
+ * Für alle anderen Verkehrsarten wird immer true zurückgegeben.
+ *
+ * @param zaehlung
+ * @param activeZaehlung
+ */
+function checkVerkehrsbeziehungen(zaehlung: LadeZaehlungDTO, activeZaehlung: ComputedRef<LadeZaehlungDTO>): boolean {
+  // Bei QU: Prüfe auf Knotenarm und Richtung
+  if (zaehlung.zaehlart === Zaehlart.QU.toString()) {
+    return activeZaehlung.value.querungsverkehr.every(activeQv =>
+        zaehlung.querungsverkehr.some(qv =>
+            qv.knotenarm === activeQv.knotenarm && qv.richtung === activeQv.richtung
+        )
+    );
+  }
+  // Bei FJS: Prüfe auf Knotenarm, Richtung und Straßenseite
+  if (zaehlung.zaehlart === Zaehlart.FJS.toString()) {
+    return activeZaehlung.value.laengsverkehr.every(activeLv =>
+        zaehlung.laengsverkehr.some(lv =>
+            lv.knotenarm === activeLv.knotenarm &&
+            lv.richtung === activeLv.richtung &&
+            lv.strassenseite === activeLv.strassenseite
+        )
+    );
+  }
+  // Bei QJS: Prüfe auf Von, Nach und Straßenseite
+  if (zaehlung.zaehlart === Zaehlart.QJS.toString()) {
+    return activeZaehlung.value.verkehrsbeziehungen.every(activeQjs =>
+        zaehlung.verkehrsbeziehungen.some(qjs =>
+            qjs.von === activeQjs.von &&
+            qjs.nach === activeQjs.nach &&
+            qjs.strassenseite === activeQjs.strassenseite
+        )
+    );
+  }
+
+  return true; // Standard-Rückgabewert, wenn andere Zaehlart
 }
 
 /**

--- a/frontend/src/components/zaehlstelle/optionsmenue/panels/ZaehlungsvergleichPanel.vue
+++ b/frontend/src/components/zaehlstelle/optionsmenue/panels/ZaehlungsvergleichPanel.vue
@@ -158,8 +158,9 @@ const helpTextDifferenzdatenBelastungsplan = computed(() => {
   }
   if (hoverSelectVergleichsdatumZeitreihe.value) {
     return (
-      "Datum der Zählung, bis zu der die Zeitreihe angezeigt werden soll (inklusive).\n" +
-      "Es können nur Zählungen gleicher Zählart verglichen werden. Der Tageswert kann immer verglichen werden, ansonsten muss in den Vergleichszählungen der gewählten Zeitblock bzw. die gewählte Stunde vorhanden sein."
+        (["FJS", "QJS", "QU"].includes(activeZaehlung.value.zaehlart)
+            ? "Es können nur Zählungen gleicher Zählart und mit gleichen Verkehrsbeziehungen verglichen werden. Der Tageswert kann immer verglichen werden, ansonsten muss in den Vergleichszählungen der gewählten Zeitblock bzw. die gewählte Stunde vorhanden sein."
+            : "Es können nur Zählungen gleicher Zählart verglichen werden. Der Tageswert kann immer verglichen werden, ansonsten muss in den Vergleichszählungen der gewählten Zeitblock bzw. die gewählte Stunde vorhanden sein.")
     );
   }
   return "";

--- a/frontend/src/components/zaehlstelle/optionsmenue/panels/ZaehlungsvergleichPanel.vue
+++ b/frontend/src/components/zaehlstelle/optionsmenue/panels/ZaehlungsvergleichPanel.vue
@@ -230,7 +230,7 @@ function zeitreihenVergleichsdatumCalculator(): void {
         (containsZeitblock(zaehl, chosenOptionsCopy.value.zeitblock) ||
           chosenOptionsCopy.value.zeitauswahl.toString() ===
             Zeitauswahl.TAGESWERT.toString()) &&
-          checkVerkehrsbeziehungen(zaehl)
+          checkVerkehrsbeziehungen(zaehl, activeZaehlung)
       ) {
         result.push({
           title: dateUtils.getShortVersionOfDate(
@@ -250,37 +250,41 @@ function zeitreihenVergleichsdatumCalculator(): void {
 }
 
 /**
- * Prüfung bei Zählart QU, QJS oder FJS: Alle Verkehrsbeziehungen und Pfeile der in den Optionen gewählten Zählung müssen in der zu prüfenden Zählung vorhanden sein.
+ * Prüfung bei Zählart QU, QJS oder FJS: Alle Verkehrsbeziehungen und Pfeile müssen mit der aktive Zählung übereinstimmen.
  * Für alle anderen Verkehrsarten wird immer true zurückgegeben.
  *
- * @param zaehlung
+ * @param zaehlung zu prüfende Zaehlung
+ * @param activeZaehlung aktive Zaehlung
  */
-function checkVerkehrsbeziehungen(zaehlung: LadeZaehlungDTO): boolean {
+function checkVerkehrsbeziehungen(zaehlung: LadeZaehlungDTO, activeZaehlung: ComputedRef<LadeZaehlungDTO>): boolean {
   // Bei QU: Prüfe auf Knotenarm und Richtung
   if (zaehlung.zaehlart === Zaehlart.QU.toString()) {
-    return chosenOptionsCopy.value.chosenQuerungsverkehre.every(chosenQv =>
+    return activeZaehlung.value.querungsverkehr.length === zaehlung.querungsverkehr.length &&
+        activeZaehlung.value.querungsverkehr.every(activeQv =>
         zaehlung.querungsverkehr.some(qv =>
-            qv.knotenarm === chosenQv.knotenarm && qv.richtung === chosenQv.richtung
+            qv.knotenarm === activeQv.knotenarm && qv.richtung === activeQv.richtung
         )
     );
   }
   // Bei FJS: Prüfe auf Knotenarm, Richtung und Straßenseite
   if (zaehlung.zaehlart === Zaehlart.FJS.toString()) {
-    return chosenOptionsCopy.value.chosenLaengsverkehre.every(ChosenLv =>
+    return activeZaehlung.value.laengsverkehr.length === zaehlung.laengsverkehr.length &&
+        activeZaehlung.value.laengsverkehr.every(activeLv =>
         zaehlung.laengsverkehr.some(lv =>
-            lv.knotenarm === ChosenLv.knotenarm &&
-            lv.richtung === ChosenLv.richtung &&
-            lv.strassenseite === ChosenLv.strassenseite
+            lv.knotenarm === activeLv.knotenarm &&
+            lv.richtung === activeLv.richtung &&
+            lv.strassenseite === activeLv.strassenseite
         )
     );
   }
   // Bei QJS: Prüfe auf Von, Nach und Straßenseite
   if (zaehlung.zaehlart === Zaehlart.QJS.toString()) {
-    return chosenOptionsCopy.value.chosenVerkehrsbeziehungen.every(chosenVb =>
+    return activeZaehlung.value.verkehrsbeziehungen.length === zaehlung.verkehrsbeziehungen.length &&
+        activeZaehlung.value.verkehrsbeziehungen.every(activeVb =>
         zaehlung.verkehrsbeziehungen.some(qjs =>
-            qjs.von === chosenVb.von &&
-            qjs.nach === chosenVb.nach &&
-            qjs.strassenseite === chosenVb.strassenseite
+            qjs.von === activeVb.von &&
+            qjs.nach === activeVb.nach &&
+            qjs.strassenseite === activeVb.strassenseite
         )
     );
   }

--- a/frontend/src/components/zaehlstelle/optionsmenue/panels/ZaehlungsvergleichPanel.vue
+++ b/frontend/src/components/zaehlstelle/optionsmenue/panels/ZaehlungsvergleichPanel.vue
@@ -209,10 +209,11 @@ function vergleichsdatumCalculator(): void {
 
 /**
  * Diese Methode ermittelt alle Zählungen für die Zeitreihendarstellung.
- * Die für die Differenzendarstellung relevanten Zählungen sind:
+ * Die für die Zeitreihendarstellung relevanten Zählungen sind:
  * - Welche älter als oder gleich alt wie die Basiszählung sind.
  * - Welche die selbe Zählart besitzt.
  * - Welche den gewählten Zeitblock besitzt.
+ * - Bei QU, QJS, FJS: Welche übereinstimmende Bewegungsbeziehungen/Pfeilen besitzt.
  * */
 function zeitreihenVergleichsdatumCalculator(): void {
   const result: Array<KeyVal> = new Array<KeyVal>();
@@ -230,7 +231,7 @@ function zeitreihenVergleichsdatumCalculator(): void {
         (containsZeitblock(zaehl, chosenOptionsCopy.value.zeitblock) ||
           chosenOptionsCopy.value.zeitauswahl.toString() ===
             Zeitauswahl.TAGESWERT.toString()) &&
-          checkVerkehrsbeziehungen(zaehl, activeZaehlung)
+          checkBewegungsbeziehungen(zaehl, activeZaehlung)
       ) {
         result.push({
           title: dateUtils.getShortVersionOfDate(
@@ -250,13 +251,13 @@ function zeitreihenVergleichsdatumCalculator(): void {
 }
 
 /**
- * Prüfung bei Zählart QU, QJS oder FJS: Alle Verkehrsbeziehungen und Pfeile müssen mit der aktive Zählung übereinstimmen.
+ * Prüfung bei Zählart QU, QJS oder FJS: Alle Bewegungsbeziehungen/Pfeile müssen mit der aktive Zählung übereinstimmen.
  * Für alle anderen Verkehrsarten wird immer true zurückgegeben.
  *
  * @param zaehlung zu prüfende Zaehlung
  * @param activeZaehlung aktive Zaehlung
  */
-function checkVerkehrsbeziehungen(zaehlung: LadeZaehlungDTO, activeZaehlung: ComputedRef<LadeZaehlungDTO>): boolean {
+function checkBewegungsbeziehungen(zaehlung: LadeZaehlungDTO, activeZaehlung: ComputedRef<LadeZaehlungDTO>): boolean {
   // Bei QU: Prüfe auf Knotenarm und Richtung
   if (zaehlung.zaehlart === Zaehlart.QU.toString()) {
     return activeZaehlung.value.querungsverkehr.length === zaehlung.querungsverkehr.length &&

--- a/frontend/src/components/zaehlstelle/optionsmenue/panels/ZaehlungsvergleichPanel.vue
+++ b/frontend/src/components/zaehlstelle/optionsmenue/panels/ZaehlungsvergleichPanel.vue
@@ -161,7 +161,7 @@ const helpTextDifferenzdatenBelastungsplan = computed(() => {
   }
   if (hoverSelectVergleichsdatumZeitreihe.value) {
     const part: string =
-      "Der Tageswert kann immer verglichen werden, ansonsten muss in den Vergleichszählungen der gewählten Zeitblock bzw. die gewählte Stunde vorhanden sein.";
+      "Der Tageswert kann immer verglichen werden, ansonsten muss in den Vergleichszählungen der gewählten Zeitblock bzw. die gewählte Stunde vorhanden sein. ";
     return [
       Zaehlart.FJS.toString(),
       Zaehlart.QJS.toString(),


### PR DESCRIPTION
# Description

Anpassung des Filtermenü Zählungsvergleich hinsichtlich Zeitreihe für die neuen Zählarten

# Issue References

[FV-262](https://jira.muenchen.de/browse/FV-262)
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [x] Acceptance criteria are met
- [x] Testing is done (unit-tests, DEV-environment)
- [x] Build/Test workflow has successfully finished
- [x] Release notes are complemented
- [x] Documentation is complemented (operator manual, system specification, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened comparison filtering: for FJS, QJS, and QU counting types, candidates must now match traffic/relationship entries exactly.
  * Previously selected comparisons are automatically cleared if they become invalid after recalculation.

* **Enhancements**
  * Updated hover/help text to explain the stricter traffic-relationship constraint for FJS, QJS, and QU.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->