### PR TITLE
FV-135 Layer für Stadtbezirke Stadtviertel und Lichzeichenanlagen nicht mehr existent

### DIFF
--- a/frontend/src/components/map/ZaehlstelleMap.vue
+++ b/frontend/src/components/map/ZaehlstelleMap.vue
@@ -203,9 +203,9 @@ function createBaseLayers(): L.Control.LayersObject {
 
 function createOverlayLayers(): L.Control.LayersObject {
   const stadtbezirke = L.tileLayer.wms(
-    "https://geoportal.muenchen.de/geoserver/gsm/wms?",
+    "https://agswebwip001.srv.muenchen.de/arcgis/services/basis/MapServer/WMSServer?",
     {
-      layers: "gsm:stadtbezirk",
+      layers: "Stadtbezirke",
       className: "Stadtbezirke",
       transparent: true,
       format: "image/png",
@@ -213,9 +213,9 @@ function createOverlayLayers(): L.Control.LayersObject {
     }
   );
   const stadtviertel = L.tileLayer.wms(
-    "https://geoportal.muenchen.de/geoserver/gsm/wms?",
+    "https://agswebwip001.srv.muenchen.de/arcgis/services/basis/MapServer/WMSServer?",
     {
-      layers: "gsm:vablock_viertel_dave",
+      layers: "Stadtviertel",
       className: "Stadtviertel",
       transparent: true,
       format: "image/png",
@@ -223,9 +223,9 @@ function createOverlayLayers(): L.Control.LayersObject {
     }
   );
   const lichtsignalanlagen = L.tileLayer.wms(
-    "https://geoportal.muenchen.de/geoserver/kvr/wms?",
+    "https://agswebwip001.srv.muenchen.de/arcgis/services/basis/MapServer/WMSServer?",
     {
-      layers: "kvr:lsa_dave",
+      layers: "Lichtzeichenanlagen_Punkte",
       className: "Lichtsignalanlagen",
       transparent: true,
       format: "image/png",


### PR DESCRIPTION
# Description

 Layer für Stadtbezirke Stadtviertel und Lichzeichenanlagen nicht mehr existent. Die Quelle wurde durch Arcgis ersetzt.

# Issue References

FV-135
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [ ] Acceptance criteria are met
- [ ] Testing is done (unit-tests, DEV-environment)
- [ ] Build/Test workflow has successfully finished
- [ ] Release notes are complemented
- [ ] Documentation is complemented (operator manual, system specification, etc.)