### PR TITLE
Fehlerhafter PDF export

### DIFF
--- a/frontend/src/components/messstelle/charts/BelastungsplanMessquerschnittCard.vue
+++ b/frontend/src/components/messstelle/charts/BelastungsplanMessquerschnittCard.vue
@@ -440,7 +440,7 @@ function addTextSouthSide(
     isSvpInBelastungsPlan.value,
     chosenOptionsCopyFahrzeuge.value.schwerverkehr,
     chosenOptionsCopyFahrzeuge.value.gueterverkehr,
-    chosenOptionsCopyFahrzeuge.value.kraftfahrzeugverkehr
+    chosenOptionsCopyFahrzeuge.value.kraftfahrzeugverkehr,
   ].filter(Boolean).length;
   // Über textposition wird bestimmt, ob der Wert in Klammern gesetzt werden muss.
   let textposition = countTexts - 1;

--- a/frontend/src/components/zaehlstelle/ZaehldatenDiagramme.vue
+++ b/frontend/src/components/zaehlstelle/ZaehldatenDiagramme.vue
@@ -62,7 +62,11 @@
         >
           <div v-if="hasSelectedVerkehrsarten">
             <belastungsplan-kreuzung-svg
-              v-if="!belastungsplanDTO.kreisverkehr && !isQJSZaehlung && !isFJSZaehlung"
+              v-if="
+                !belastungsplanDTO.kreisverkehr &&
+                !isQJSZaehlung &&
+                !isFJSZaehlung
+              "
               :dimension="contentHeight"
               :data="belastungsplanDTO as LadeBelastungsplanDTO"
               @print="storeSvg($event)"
@@ -79,7 +83,11 @@
             />
 
             <belastungsplan-qjs-svg
-              v-if="!belastungsplanDTO.kreisverkehr && isQJSZaehlung && !isFJSZaehlung"
+              v-if="
+                !belastungsplanDTO.kreisverkehr &&
+                isQJSZaehlung &&
+                !isFJSZaehlung
+              "
               :dimension="contentHeight"
               :data="belastungsplanDTO"
               @print="storeSvg($event)"
@@ -87,7 +95,11 @@
             />
 
             <belastungsplan-fjs-svg
-              v-if="!belastungsplanDTO.kreisverkehr && !isQJSZaehlung && isFJSZaehlung"
+              v-if="
+                !belastungsplanDTO.kreisverkehr &&
+                !isQJSZaehlung &&
+                isFJSZaehlung
+              "
               :dimension="contentHeight"
               :data="belastungsplanDTO as LadeBelastungsplanQjsDTO"
               @print="storeSvg($event)"
@@ -211,8 +223,8 @@ import PdfReportMenue from "@/components/common/PdfReportMenue.vue";
 import ProgressLoader from "@/components/common/ProgressLoader.vue";
 import SpeedDial from "@/components/messstelle/charts/SpeedDial.vue";
 import BelastungsplanCard from "@/components/zaehlstelle/charts/BelastungsplanCard.vue";
-import BelastungsplanKreuzungSvg from "@/components/zaehlstelle/charts/BelastungsplanKreuzungSvg.vue";
 import BelastungsplanFjsSvg from "@/components/zaehlstelle/charts/BelastungsplanFjsSvg.vue";
+import BelastungsplanKreuzungSvg from "@/components/zaehlstelle/charts/BelastungsplanKreuzungSvg.vue";
 import BelastungsplanKreuzungSvgSchematischeUebersicht from "@/components/zaehlstelle/charts/BelastungsplanKreuzungSvgSchematischeUebersicht.vue";
 import BelastungsplanQjsSvg from "@/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue";
 import HeatmapCard from "@/components/zaehlstelle/charts/HeatmapCard.vue";

--- a/frontend/src/components/zaehlstelle/ZaehldatenDiagramme.vue
+++ b/frontend/src/components/zaehlstelle/ZaehldatenDiagramme.vue
@@ -62,7 +62,7 @@
         >
           <div v-if="hasSelectedVerkehrsarten">
             <belastungsplan-kreuzung-svg
-              v-show="!belastungsplanDTO.kreisverkehr && !isQJSZaehlung && !isFJSZaehlung"
+              v-if="!belastungsplanDTO.kreisverkehr && !isQJSZaehlung && !isFJSZaehlung"
               :dimension="contentHeight"
               :data="belastungsplanDTO as LadeBelastungsplanDTO"
               @print="storeSvg($event)"
@@ -70,7 +70,7 @@
             />
 
             <belastungsplan-card
-              v-show="belastungsplanDTO.kreisverkehr"
+              v-if="belastungsplanDTO.kreisverkehr"
               ref="belastungsplanCard"
               :dimension="contentHeight"
               :belastungsplan-data="belastungsplanDTO as LadeBelastungsplanDTO"
@@ -79,7 +79,7 @@
             />
 
             <belastungsplan-qjs-svg
-              v-show="!belastungsplanDTO.kreisverkehr && isQJSZaehlung && !isFJSZaehlung"
+              v-if="!belastungsplanDTO.kreisverkehr && isQJSZaehlung && !isFJSZaehlung"
               :dimension="contentHeight"
               :data="belastungsplanDTO"
               @print="storeSvg($event)"
@@ -87,7 +87,7 @@
             />
 
             <belastungsplan-fjs-svg
-              v-show="!belastungsplanDTO.kreisverkehr && !isQJSZaehlung && isFJSZaehlung"
+              v-if="!belastungsplanDTO.kreisverkehr && !isQJSZaehlung && isFJSZaehlung"
               :dimension="contentHeight"
               :data="belastungsplanDTO as LadeBelastungsplanQjsDTO"
               @print="storeSvg($event)"

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
@@ -1235,18 +1235,15 @@ const sumArrowsOneTwo = computed(() => {
     sum = props.data.value1.valuesStrassenseite.find(
       (k) => k.strassenseite === Himmelsrichtung.W
     )?.value;
-  }
-  else if (availableKnotenarmNummern.value.includes(2)) {
+  } else if (availableKnotenarmNummern.value.includes(2)) {
     sum = props.data.value1.valuesStrassenseite.find(
       (k) => k.strassenseite === Himmelsrichtung.N
     )?.value;
-  }
-  else if (availableKnotenarmNummern.value.includes(5)) {
+  } else if (availableKnotenarmNummern.value.includes(5)) {
     sum = props.data.value1.valuesStrassenseite.find(
       (k) => k.strassenseite === Himmelsrichtung.NW
     )?.value;
-  }
-  else if (availableKnotenarmNummern.value.includes(6)) {
+  } else if (availableKnotenarmNummern.value.includes(6)) {
     sum = props.data.value1.valuesStrassenseite.find(
       (k) => k.strassenseite === Himmelsrichtung.NO
     )?.value;
@@ -1263,18 +1260,15 @@ const sumArrowsThreeFour = computed(() => {
     sum = props.data.value1.valuesStrassenseite.find(
       (k) => k.strassenseite === Himmelsrichtung.O
     )?.value;
-  }
-  else if (availableKnotenarmNummern.value.includes(2)) {
+  } else if (availableKnotenarmNummern.value.includes(2)) {
     sum = props.data.value1.valuesStrassenseite.find(
       (k) => k.strassenseite === Himmelsrichtung.S
     )?.value;
-  }
-  else if (availableKnotenarmNummern.value.includes(5)) {
+  } else if (availableKnotenarmNummern.value.includes(5)) {
     sum = props.data.value1.valuesStrassenseite.find(
       (k) => k.strassenseite === Himmelsrichtung.SO
     )?.value;
-  }
-  else if (availableKnotenarmNummern.value.includes(6)) {
+  } else if (availableKnotenarmNummern.value.includes(6)) {
     sum = props.data.value1.valuesStrassenseite.find(
       (k) => k.strassenseite === Himmelsrichtung.SW
     )?.value;

--- a/frontend/src/components/zaehlstelle/optionsmenue/panels/ZeitauswahlPanel.vue
+++ b/frontend/src/components/zaehlstelle/optionsmenue/panels/ZeitauswahlPanel.vue
@@ -359,10 +359,12 @@ watch(
 /**
  * Passt die Controls anhand ihrer Abhängigkeiten zu anderen Optionen an.
  */
-function adaptOptionsUpdate(){
-  if (isOnlyFussgaengerSelected.value &&
-      chosenOptionsCopy.value.zeitauswahl === Zeitauswahl.TAGESWERT &&
-      isTeilzaehlung.value ){
+function adaptOptionsUpdate() {
+  if (
+    isOnlyFussgaengerSelected.value &&
+    chosenOptionsCopy.value.zeitauswahl === Zeitauswahl.TAGESWERT &&
+    isTeilzaehlung.value
+  ) {
     chosenOptionsCopy.value.zeitauswahl = Zeitauswahl.BLOCK;
     const zbMax =
       zeitblockOrder.find((zb) =>


### PR DESCRIPTION


# Description
If the load plans are rendered using v-show, the components are mounted in a hidden state. This causes a `draw/emit` to be executed for each BLP—the blob that arrives last then determines the final rendered image.

Change v-show to v-if to generate only the BLP currently in view for PDF export.

# Issue References

FV-325
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [x] Acceptance criteria are met
- [x] Testing is done (unit-tests, DEV-environment)
- [x] Build/Test workflow has successfully finished
- [x] Release notes are complemented
- [x] Documentation is complemented (operator manual, system specification, etc.)