### PR TITLE
FV-354 BLP Schriftart und Pfeile nicht wie bei bestehenden Zählarten

### DIFF
--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanConstants.ts
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanConstants.ts
@@ -20,5 +20,5 @@ export const BelastungsplanConstants = {
   inaktivColor: "#E0E0E0",
 
   // kleinstmögliche Skalierung eines Pfeils, damit er überhaupt angezeigt wird
-  minimum_arrow_scale: 0.005,
+  minimum_arrow_scale: 0.05,
 } as const;

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanConstants.ts
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanConstants.ts
@@ -19,7 +19,6 @@ export const BelastungsplanConstants = {
   inaktivColor: "#E0E0E0",
   legendColor: "#757575",
 
-
   // kleinstmögliche Skalierung eines Pfeils, damit er überhaupt angezeigt wird
   minimum_arrow_scale: 0.05,
 } as const;

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanConstants.ts
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanConstants.ts
@@ -13,11 +13,12 @@ export const BelastungsplanConstants = {
 
   fontfamily: "Roboto, Arial, Helvetica, sans-serif",
 
-  // Farben Differenzdatendarstellung
   zunahmeValueColor: "#F44336",
   abnahmeValueColor: "#4CAF50",
   gleichValueColor: "#000000",
   inaktivColor: "#E0E0E0",
+  legendColor: "#757575",
+
 
   // kleinstmögliche Skalierung eines Pfeils, damit er überhaupt angezeigt wird
   minimum_arrow_scale: 0.05,

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanFjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanFjsSvg.vue
@@ -33,7 +33,7 @@
               font-weight: normal;
               font-stretch: normal;
               font-size: ${belastungsplanMethods.maxlineWidth};
-              font-familiy: ${BelastungsplanConstants.fontfamily};
+              family: ${BelastungsplanConstants.fontfamily};
               font-variant-ligatures: normal;
               font-variant-caps: normal;
               font-variant-numeric: normal;
@@ -80,7 +80,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth};
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -121,7 +121,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -184,7 +184,7 @@
               font-weight: normal;
               font-stretch: normal;
               font-size: ${belastungsplanMethods.maxlineWidth}px;
-              font-familiy: ${BelastungsplanConstants.fontfamily};
+              family: ${BelastungsplanConstants.fontfamily};
               font-variant-ligatures: normal;
               font-variant-caps: normal;
               font-variant-numeric: normal;
@@ -207,7 +207,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -238,7 +238,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -294,7 +294,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -368,7 +368,7 @@
                 xml:space="preserve"
                 :style="`
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
                   direction: ltr;
@@ -399,7 +399,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -437,7 +437,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -475,7 +475,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -513,7 +513,7 @@
                 font-weight: bold;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -540,7 +540,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -581,7 +581,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -608,7 +608,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -630,7 +630,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -657,7 +657,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -682,7 +682,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -709,7 +709,7 @@
                     font-weight: bold;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -758,7 +758,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -785,7 +785,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -807,7 +807,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -834,7 +834,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -859,7 +859,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -886,7 +886,7 @@
                     font-weight: bold;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -931,7 +931,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -979,7 +979,7 @@
                 xml:space="preserve"
                 :style="`
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
                   direction: ltr;
@@ -1010,7 +1010,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -1047,7 +1047,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -1084,7 +1084,7 @@
                 font-weight: bold;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -1111,7 +1111,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1152,7 +1152,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1179,7 +1179,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -1201,7 +1201,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1228,7 +1228,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -1253,7 +1253,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1280,7 +1280,7 @@
                     font-weight: bold;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -1329,7 +1329,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1356,7 +1356,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -1378,7 +1378,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1405,7 +1405,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -1430,7 +1430,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1457,7 +1457,7 @@
                     font-weight: bold;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -1502,7 +1502,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -1529,7 +1529,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1563,7 +1563,7 @@
                 xml:space="preserve"
                 :style="`
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
                   direction: ltr;
@@ -1594,7 +1594,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -1621,7 +1621,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1644,7 +1644,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -1671,7 +1671,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1694,7 +1694,7 @@
                 font-weight: bold;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -1721,7 +1721,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1762,7 +1762,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1789,7 +1789,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -1811,7 +1811,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1838,7 +1838,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -1863,7 +1863,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1890,7 +1890,7 @@
                     font-weight: bold;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -1939,7 +1939,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1966,7 +1966,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -1988,7 +1988,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2015,7 +2015,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -2040,7 +2040,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2067,7 +2067,7 @@
                     font-weight: bold;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -2112,7 +2112,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -2138,7 +2138,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2172,7 +2172,7 @@
                 xml:space="preserve"
                 :style="`
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
                   direction: ltr;
@@ -2203,7 +2203,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -2229,7 +2229,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2252,7 +2252,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -2278,7 +2278,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2300,7 +2300,7 @@
                 font-weight: bold;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -2327,7 +2327,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2368,7 +2368,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2395,7 +2395,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -2417,7 +2417,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2444,7 +2444,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -2469,7 +2469,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2496,7 +2496,7 @@
                     font-weight: bold;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -2545,7 +2545,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2572,7 +2572,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -2594,7 +2594,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2621,7 +2621,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -2645,7 +2645,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2672,7 +2672,7 @@
                     font-weight: bold;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -2731,7 +2731,7 @@
                 xml:space="preserve"
                 :style="`
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
                   direction: ltr;
@@ -2762,7 +2762,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -2800,7 +2800,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -2838,7 +2838,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -2876,7 +2876,7 @@
                 font-weight: bold;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -2903,7 +2903,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2944,7 +2944,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2971,7 +2971,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -2993,7 +2993,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3020,7 +3020,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -3045,7 +3045,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3072,7 +3072,7 @@
                     font-weight: bold;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -3121,7 +3121,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3148,7 +3148,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -3170,7 +3170,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3197,7 +3197,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -3222,7 +3222,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3249,7 +3249,7 @@
                     font-weight: bold;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -3294,7 +3294,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -3346,7 +3346,7 @@
                 xml:space="preserve"
                 :style="`
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
                   direction: ltr;
@@ -3378,7 +3378,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -3416,7 +3416,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -3454,7 +3454,7 @@
                 font-weight: bold;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -3481,7 +3481,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3522,7 +3522,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3549,7 +3549,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -3571,7 +3571,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3598,7 +3598,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -3623,7 +3623,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3650,7 +3650,7 @@
                     font-weight: bold;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -3699,7 +3699,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3726,7 +3726,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -3748,7 +3748,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3775,7 +3775,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -3800,7 +3800,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3827,7 +3827,7 @@
                     font-weight: bold;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -3872,7 +3872,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -3899,7 +3899,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3933,7 +3933,7 @@
                 xml:space="preserve"
                 :style="`
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
                   direction: ltr;
@@ -3964,7 +3964,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -3991,7 +3991,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4014,7 +4014,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -4041,7 +4041,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4064,7 +4064,7 @@
                 font-weight: bold;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -4091,7 +4091,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4132,7 +4132,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4159,7 +4159,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -4181,7 +4181,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4208,7 +4208,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -4233,7 +4233,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4260,7 +4260,7 @@
                     font-weight: bold;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -4309,7 +4309,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4336,7 +4336,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -4358,7 +4358,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4385,7 +4385,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -4410,7 +4410,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4437,7 +4437,7 @@
                     font-weight: bold;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -4482,7 +4482,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -4509,7 +4509,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4543,7 +4543,7 @@
                 xml:space="preserve"
                 :style="`
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
                   direction: ltr;
@@ -4574,7 +4574,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -4601,7 +4601,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4624,7 +4624,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -4651,7 +4651,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4673,7 +4673,7 @@
                 font-weight: bold;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -4700,7 +4700,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4741,7 +4741,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4768,7 +4768,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -4790,7 +4790,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4817,7 +4817,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -4842,7 +4842,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4869,7 +4869,7 @@
                     font-weight: bold;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -4918,7 +4918,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4945,7 +4945,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -4967,7 +4967,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4994,7 +4994,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -5019,7 +5019,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -5046,7 +5046,7 @@
                     font-weight: bold;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    font-familiy: ${BelastungsplanConstants.fontfamily};
+                    family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanFjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanFjsSvg.vue
@@ -27,13 +27,13 @@
           <text
             id="verkehrsart"
             xml:space="preserve"
-            style="
+            :style="`
               font-style: normal;
               font-variant: normal;
               font-weight: normal;
               font-stretch: normal;
-              font-size: 19.7556px;
-              font-family: sans-serif;
+              font-size: ${belastungsplanMethods.maxlineWidth};
+              font-familiy: ${BelastungsplanConstants.fontfamily};
               font-variant-ligatures: normal;
               font-variant-caps: normal;
               font-variant-numeric: normal;
@@ -48,7 +48,7 @@
               fill: #000000;
               stroke-width: 28.2205;
               stroke-dasharray: none;
-            "
+            `"
             x="168.24969"
             y="1230.3373"
             transform="matrix(1.000004,0,0,1,-152.56418,35.000043)"
@@ -74,13 +74,13 @@
             <text
               id="zaehlzeit2-multirow"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 19.7556px;
-                font-family: sans-serif;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -95,7 +95,7 @@
                 fill: #000000;
                 stroke-width: 28.2205;
                 stroke-dasharray: none;
-              "
+              `"
               x="168"
               y="1210"
             >
@@ -115,13 +115,13 @@
             <text
               id="zaehlzeit1-multirow"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 19.7556px;
-                font-family: sans-serif;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -136,7 +136,7 @@
                 fill: #000000;
                 stroke-width: 28.2205;
                 stroke-dasharray: none;
-              "
+              `"
               x="168.24969"
               y="1190.3373"
               transform="translate(-150.84646,0.00360406)"
@@ -178,13 +178,13 @@
           <text
             id="compass1"
             xml:space="preserve"
-            style="
+            :style="`
               font-style: normal;
               font-variant: normal;
               font-weight: normal;
               font-stretch: normal;
-              font-size: 24.6944px;
-              font-family: RomanD;
+              font-size: ${belastungsplanMethods.maxlineWidth};
+              font-familiy: ${BelastungsplanConstants.fontfamily};
               font-variant-ligatures: normal;
               font-variant-caps: normal;
               font-variant-numeric: normal;
@@ -195,25 +195,25 @@
               text-anchor: start;
               fill: #000000;
               stroke-width: 2.2868;
-            "
+            `"
             x="141.28041"
             y="93.924416"
           >
             <tspan
               id="tspan6-1"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 24.6944px;
-                font-family: RomanD;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
                 font-variant-east-asian: normal;
                 stroke-width: 2.2868;
-              "
+              `"
             >
               N
             </tspan>
@@ -232,13 +232,13 @@
               v-if="zaehlstelleStore.getZaehlstelleHeader.stadtbezirkNummer"
               id="zaehlstelle2-multirow"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 19.7556px;
-                font-family: sans-serif;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -253,7 +253,7 @@
                 fill: #000000;
                 stroke-width: 28.2205;
                 stroke-dasharray: none;
-              "
+              `"
               x="699.24969"
               y="688.33734"
               transform="translate(324.11416)"
@@ -288,13 +288,13 @@
             <text
               id="zaehlstelle1-multirow"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 19.7556px;
-                font-family: sans-serif;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -309,7 +309,7 @@
                 fill: #000000;
                 stroke-width: 28.2205;
                 stroke-dasharray: none;
-              "
+              `"
               x="699.24969"
               y="688.33734"
               transform="translate(324.11217)"
@@ -366,16 +366,16 @@
               <text
                 id="node1_circle_text"
                 xml:space="preserve"
-                style="
-                  font-size: 19.7624px;
-                  font-family: sans-serif;
+                :style="`
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
                   direction: ltr;
                   text-anchor: start;
                   fill: #000000;
                   stroke-width: 30.9229;
-                "
+                `"
                 y="622.00684"
                 x="693.53955"
               >
@@ -393,13 +393,13 @@
               v-if="streetnameNodeOne.length === 1"
               id="node1_strassenname_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -413,7 +413,7 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               transform="rotate(-90)"
               x="-671.03851"
               y="629.34802"
@@ -431,13 +431,13 @@
               v-if="streetnameNodeOne.length > 1"
               id="node1_strassenname_multirow2_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -451,7 +451,7 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               transform="rotate(-90)"
               x="-671.03851"
               y="643.34802"
@@ -469,13 +469,13 @@
               v-if="streetnameNodeOne.length > 1"
               id="node1_strassenname_multirow1_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -489,7 +489,7 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               transform="rotate(-90)"
               x="-671.03851"
               y="615.34802"
@@ -507,13 +507,13 @@
               id="node1_sum_text"
               xml:space="preserve"
               transform="matrix(0,-0.86675092,1.153734,0,0,0)"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: bold;
                 font-stretch: normal;
-                font-size: 28.097px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -526,7 +526,7 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 43.9645;
-              "
+              `"
               x="-1207.2531"
               y="-171.53365"
             >
@@ -534,19 +534,19 @@
                 id="node1_sum_tspan"
                 x="-49.797398"
                 y="616.65149"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
                   stroke-width: 43.9645;
-                "
+                `"
               >
                 {{ sumNodeOneArrows }}
               </tspan>
@@ -575,13 +575,13 @@
                 id="arrow_node1_west_incoming_number_text"
                 xml:space="preserve"
                 transform="matrix(0,-0.86707182,1.153307,0,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -594,7 +594,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="-1206.5183"
                 y="-259.38544"
               >
@@ -602,19 +602,19 @@
                   id="arrow_node1_west_incoming_number_tspan"
                   x="-49.490978"
                   y="528.50812"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9482;
-                  "
+                  `"
                 >
                   {{ zaehlwertArrowNodeOneWestIncoming }}
                 </tspan>
@@ -624,13 +624,13 @@
                 id="arrow_node1_west_outgoing_number_text"
                 xml:space="preserve"
                 transform="matrix(0,-0.86707182,1.153307,0,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -643,7 +643,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="-1206.5183"
                 y="-230.55521"
               >
@@ -651,19 +651,19 @@
                   id="arrow_node1_west_outgoing_number_tspan"
                   x="-49.490978"
                   y="557.33826"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9482;
-                  "
+                  `"
                 >
                   {{ zaehlwertArrowNodeOneWestOutgoing }}
                 </tspan>
@@ -676,13 +676,13 @@
                 id="arrows_node1_west_sum_text"
                 xml:space="preserve"
                 transform="matrix(0,-0.86675167,1.153733,0,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -695,7 +695,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9644;
-                "
+                `"
                 x="-1207.2521"
                 y="-203.73477"
               >
@@ -703,19 +703,19 @@
                   id="arrows_node1_west_sum_tspan"
                   x="-49.797356"
                   y="584.45007"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: 28.097px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9644;
-                  "
+                  `"
                 >
                   {{ sumArrowsNodeOneWest }}
                 </tspan>
@@ -752,13 +752,13 @@
                 id="arrow_node1_east_incoming_number_text"
                 xml:space="preserve"
                 transform="matrix(0,-0.86707182,1.153307,0,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -771,7 +771,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="-1206.5183"
                 y="-115.23471"
               >
@@ -779,19 +779,19 @@
                   id="arrow_node1_east_incoming_number_tspan"
                   x="-49.490978"
                   y="672.65881"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9482;
-                  "
+                  `"
                 >
                   {{ zaehlwertArrowNodeOneEastIncoming }}
                 </tspan>
@@ -801,13 +801,13 @@
                 id="arrow_node1_east_outgoing_number_text"
                 xml:space="preserve"
                 transform="matrix(0,-0.86707182,1.153307,0,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -820,7 +820,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="-1206.5183"
                 y="-86.404541"
               >
@@ -828,19 +828,19 @@
                   id="arrow_node1_east_outgoing_number_tspan"
                   x="-49.490978"
                   y="701.48889"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9482;
-                  "
+                  `"
                 >
                   {{ zaehlwertArrowNodeOneEastOutgoing }}
                 </tspan>
@@ -853,13 +853,13 @@
                 id="arrows_node1_east_sum_text"
                 xml:space="preserve"
                 transform="matrix(0,-0.86675167,1.153733,0,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -872,7 +872,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9644;
-                "
+                `"
                 x="-1207.2521"
                 y="-59.637333"
               >
@@ -880,19 +880,19 @@
                   id="arrows_node1_east_sum_tspan"
                   x="-49.797356"
                   y="728.54749"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: 28.097px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9644;
-                  "
+                  `"
                 >
                   {{ sumArrowsNodeOneEast }}
                 </tspan>
@@ -925,13 +925,13 @@
               v-if="streetnameNodeTwo.length === 1"
               id="node2_strassenname_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -945,7 +945,7 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               x="728.96271"
               y="629.34802"
             >
@@ -977,16 +977,16 @@
               <text
                 id="node2_number_text"
                 xml:space="preserve"
-                style="
-                  font-size: 19.7624px;
-                  font-family: sans-serif;
+                :style="`
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
                   direction: ltr;
                   text-anchor: start;
                   fill: #000000;
                   stroke-width: 30.9229;
-                "
+                `"
                 y="707.33368"
                 x="779.30457"
               >
@@ -1004,13 +1004,13 @@
               v-if="streetnameNodeTwo.length > 1"
               id="node2_strassenname_multirow2_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -1024,7 +1024,7 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               x="728.96271"
               y="643.34802"
             >
@@ -1041,13 +1041,13 @@
               v-if="streetnameNodeTwo.length > 1"
               id="node2_strassenname_multirow1_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -1061,7 +1061,7 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               x="728.96271"
               y="615.34802"
             >
@@ -1078,13 +1078,13 @@
               id="node2_sum_text"
               xml:space="preserve"
               transform="scale(0.86675092,1.153734)"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: bold;
                 font-stretch: normal;
-                font-size: 28.097px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -1097,7 +1097,7 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 43.9645;
-              "
+              `"
               x="407.97421"
               y="-171.52608"
             >
@@ -1105,19 +1105,19 @@
                 id="node2_sum_tspan"
                 x="1565.4299"
                 y="616.65906"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
                   stroke-width: 43.9645;
-                "
+                `"
               >
                 {{ sumNodeTwoArrows }}
               </tspan>
@@ -1146,13 +1146,13 @@
                 id="arrow_node2_north_incoming_number_text"
                 xml:space="preserve"
                 transform="scale(0.86707182,1.153307)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1165,7 +1165,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="406.98672"
                 y="-259.38541"
               >
@@ -1173,19 +1173,19 @@
                   id="arrow_node2_north_incoming_number_tspan"
                   x="1564.014"
                   y="528.50812"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9482;
-                  "
+                  `"
                 >
                   {{ zaehlwertArrowNodeTwoNorthIncoming }}
                 </tspan>
@@ -1195,13 +1195,13 @@
                 id="arrow_node2_north_outgoing_number_text"
                 xml:space="preserve"
                 transform="scale(0.86707182,1.153307)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1214,7 +1214,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="406.98672"
                 y="-230.55528"
               >
@@ -1222,19 +1222,19 @@
                   id="arrow_node2_north_outgoing_number_tspan"
                   x="1564.014"
                   y="557.33826"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9482;
-                  "
+                  `"
                 >
                   {{ zaehlwertArrowNodeTwoNorthOutgoing }}
                 </tspan>
@@ -1247,13 +1247,13 @@
                 id="arrows_node2_north_sum_text"
                 xml:space="preserve"
                 transform="scale(0.86675167,1.153733)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1266,7 +1266,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9644;
-                "
+                `"
                 x="407.97394"
                 y="-203.73479"
               >
@@ -1274,19 +1274,19 @@
                   id="arrows_node2_north_sum_tspan"
                   x="1565.4286"
                   y="584.45001"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: 28.097px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9644;
-                  "
+                  `"
                 >
                   {{ sumArrowsNodeTwoNorth }}
                 </tspan>
@@ -1323,13 +1323,13 @@
                 id="arrow_node2_south_incoming_number_text"
                 xml:space="preserve"
                 transform="scale(0.86707182,1.153307)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1342,7 +1342,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="406.98672"
                 y="-115.2347"
               >
@@ -1350,19 +1350,19 @@
                   id="arrow_node2_south_incoming_number_tspan"
                   x="1564.014"
                   y="672.65881"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9482;
-                  "
+                  `"
                 >
                   {{ zaehlwertArrowNodeTwoSouthIncoming }}
                 </tspan>
@@ -1372,13 +1372,13 @@
                 id="arrow_node2_south_outgoing_number_text"
                 xml:space="preserve"
                 transform="scale(0.86707182,1.153307)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1391,7 +1391,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="406.98669"
                 y="-86.404564"
               >
@@ -1399,19 +1399,19 @@
                   id="arrow_node2_south_outgoing_number_tspan"
                   x="1564.014"
                   y="701.48889"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9482;
-                  "
+                  `"
                 >
                   {{ zaehlwertArrowNodeTwoSouthOutgoing }}
                 </tspan>
@@ -1424,13 +1424,13 @@
                 id="arrows_node2_south_sum_text"
                 xml:space="preserve"
                 transform="scale(0.86675167,1.153733)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1443,7 +1443,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9644;
-                "
+                `"
                 x="407.97397"
                 y="-59.637352"
               >
@@ -1451,19 +1451,19 @@
                   id="arrows_node2_south_sum_tspan"
                   x="1565.4287"
                   y="728.54749"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: 28.097px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9644;
-                  "
+                  `"
                 >
                   {{ sumArrowsNodeTwoSouth }}
                 </tspan>
@@ -1496,13 +1496,13 @@
               v-if="streetnameNodeThree.length === 1"
               id="node3_strassenname_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -1516,26 +1516,26 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               transform="rotate(-90)"
               x="-962.48126"
               y="705.79083"
             >
               <tspan
                 id="node3_strassenname_tspan"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 22.3767px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
                   stroke-width: 26.4927;
-                "
+                `"
                 x="-962.48126"
                 y="705.79083"
               >
@@ -1561,16 +1561,16 @@
               <text
                 id="node3_number_text"
                 xml:space="preserve"
-                style="
-                  font-size: 19.7624px;
-                  font-family: sans-serif;
+                :style="`
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
                   direction: ltr;
                   text-anchor: start;
                   fill: #000000;
                   stroke-width: 30.9229;
-                "
+                `"
                 y="792.38141"
                 x="693.75189"
               >
@@ -1588,13 +1588,13 @@
               v-if="streetnameNodeThree.length > 1"
               id="node3_strassenname_multirow2_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -1608,26 +1608,26 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               transform="rotate(-90)"
               x="-962.48126"
               y="719.79083"
             >
               <tspan
                 id="node3_strassenname_multirow2_tspan"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 22.3767px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
                   stroke-width: 26.4927;
-                "
+                `"
                 x="-962.48126"
                 y="719.79083"
               >
@@ -1638,13 +1638,13 @@
               v-if="streetnameNodeThree.length > 1"
               id="node3_strassenname_multirow1_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -1658,26 +1658,26 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               transform="rotate(-90)"
               x="-962.48126"
               y="691.79083"
             >
               <tspan
                 id="node3_strassenname_multirow1_tspan"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 22.3767px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
                   stroke-width: 26.4927;
-                "
+                `"
                 x="-962.48126"
                 y="691.79083"
               >
@@ -1688,13 +1688,13 @@
               id="node3_sum_text"
               xml:space="preserve"
               transform="matrix(0,-0.86675092,1.153734,0,0,0)"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: bold;
                 font-stretch: normal;
-                font-size: 28.097px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -1707,7 +1707,7 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 43.9645;
-              "
+              `"
               x="-2630.3494"
               y="-171.53365"
             >
@@ -1715,19 +1715,19 @@
                 id="node3_sum_tspan"
                 x="-1472.8937"
                 y="616.65149"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
                   stroke-width: 43.9645;
-                "
+                `"
               >
                 {{ sumNodeThreeArrows }}
               </tspan>
@@ -1756,13 +1756,13 @@
                 id="arrow_node3_east_incoming_number_text"
                 xml:space="preserve"
                 transform="matrix(0,-0.86707182,1.153307,0,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1775,7 +1775,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="-2629.0879"
                 y="-115.23471"
               >
@@ -1783,19 +1783,19 @@
                   id="arrow_node3_east_incoming_number_tspan"
                   x="-1472.0605"
                   y="672.65881"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9482;
-                  "
+                  `"
                 >
                   {{ zaehlwertArrowNodeThreeEastIncoming }}
                 </tspan>
@@ -1805,13 +1805,13 @@
                 id="arrow_node3_east_outgoing_number_text"
                 xml:space="preserve"
                 transform="matrix(0,-0.86707182,1.153307,0,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1824,7 +1824,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="-2629.0879"
                 y="-86.404541"
               >
@@ -1832,19 +1832,19 @@
                   id="arrow_node3_east_outgoing_number_tspan"
                   x="-1472.0605"
                   y="701.48889"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9482;
-                  "
+                  `"
                 >
                   {{ zaehlwertArrowNodeThreeEastOutgoing }}
                 </tspan>
@@ -1857,13 +1857,13 @@
                 id="arrows_node3_east_sum_text"
                 xml:space="preserve"
                 transform="matrix(0,-0.86675167,1.153733,0,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1876,7 +1876,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9644;
-                "
+                `"
                 x="-2630.3472"
                 y="-59.637333"
               >
@@ -1884,19 +1884,19 @@
                   id="arrows_node3_east_sum_tspan"
                   x="-1472.8923"
                   y="728.54749"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: 28.097px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9644;
-                  "
+                  `"
                 >
                   {{ sumArrowsNodeThreeEast }}
                 </tspan>
@@ -1933,13 +1933,13 @@
                 id="arrow_node3_west_outgoing_number_text"
                 xml:space="preserve"
                 transform="matrix(0,-0.86707182,1.153307,0,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1952,7 +1952,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="-2629.0879"
                 y="-259.38544"
               >
@@ -1960,19 +1960,19 @@
                   id="arrow_node3_west_outgoing_number_tspan"
                   x="-1472.0605"
                   y="528.50812"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9482;
-                  "
+                  `"
                 >
                   {{ zaehlwertArrowNodeThreeWestOutgoing }}
                 </tspan>
@@ -1982,13 +1982,13 @@
                 id="arrow_node3_west_incoming_number_text"
                 xml:space="preserve"
                 transform="matrix(0,-0.86707182,1.153307,0,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2001,7 +2001,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="-2629.0879"
                 y="-230.55521"
               >
@@ -2009,19 +2009,19 @@
                   id="arrow_node3_west_incoming_number_tspan"
                   x="-1472.0605"
                   y="557.33826"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9482;
-                  "
+                  `"
                 >
                   {{ zaehlwertArrowNodeThreeWestIncoming }}
                 </tspan>
@@ -2034,13 +2034,13 @@
                 id="arrows_node3_west_sum_text"
                 xml:space="preserve"
                 transform="matrix(0,-0.86675167,1.153733,0,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2053,7 +2053,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9644;
-                "
+                `"
                 x="-2630.3472"
                 y="-203.73477"
               >
@@ -2061,19 +2061,19 @@
                   id="arrows_node3_west_sum_tspan"
                   x="-1472.8923"
                   y="584.45007"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: 28.097px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9644;
-                  "
+                  `"
                 >
                   {{ sumArrowsNodeThreeWest }}
                 </tspan>
@@ -2106,13 +2106,13 @@
               v-if="streetnameNodeFour.length === 1"
               id="node4_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -2126,25 +2126,25 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               x="437.52008"
               y="705.79083"
             >
               <tspan
                 id="node4_strassenname_tspan"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 22.3767px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
                   stroke-width: 26.4927;
-                "
+                `"
                 x="437.52008"
                 y="705.79083"
               >
@@ -2170,16 +2170,16 @@
               <text
                 id="node4_number_text"
                 xml:space="preserve"
-                style="
-                  font-size: 19.7624px;
-                  font-family: sans-serif;
+                :style="`
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
                   direction: ltr;
                   text-anchor: start;
                   fill: #000000;
                   stroke-width: 30.9229;
-                "
+                `"
                 y="707.20343"
                 x="608.34302"
               >
@@ -2197,13 +2197,13 @@
               v-if="streetnameNodeFour.length > 1"
               id="node4_strassenname_multirow2_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -2217,25 +2217,25 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               x="437.52008"
               y="719.79083"
             >
               <tspan
                 id="node4_strassenname_multirow2_tspan"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 22.3767px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
                   stroke-width: 26.4927;
-                "
+                `"
                 x="437.52008"
                 y="719.79083"
               >
@@ -2246,13 +2246,13 @@
               v-if="streetnameNodeFour.length > 1"
               id="node4_strassenname_multirow1_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -2266,25 +2266,25 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               x="437.52008"
               y="691.79083"
             >
               <tspan
                 id="node4_strassenname_multirow1_tspan"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 22.3767px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
                   stroke-width: 26.4927;
-                "
+                `"
                 x="437.52008"
                 y="691.79083"
               >
@@ -2294,14 +2294,13 @@
             <text
               id="node4_sum_text"
               xml:space="preserve"
-              transform="scale(0.86675167,1.153733)"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: bold;
                 font-stretch: normal;
-                font-size: 28.097px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -2314,27 +2313,27 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 43.9644;
-              "
-              x="-1015.1211"
-              y="-171.52489"
+              `"
+              x="-1034.2489"
+              y="-78.905891"
             >
               <tspan
+                x="123.20578"
+                y="709.27856"
                 id="node4_sum_tspan"
-                x="142.33362"
-                y="616.65955"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
                   stroke-width: 43.9644;
-                "
+                `"
               >
                 {{ sumNodeFourArrows }}
               </tspan>
@@ -2363,13 +2362,13 @@
                 id="arrow_node4_south_outgoing_number_text"
                 xml:space="preserve"
                 transform="scale(0.86707182,1.153307)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2382,7 +2381,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="-1015.5829"
                 y="-115.2348"
               >
@@ -2390,19 +2389,19 @@
                   id="arrow_node4_south_outgoing_number_tspan"
                   x="141.44441"
                   y="672.65881"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9482;
-                  "
+                  `"
                 >
                   {{ zaehlwertArrowNodeFourSouthOutgoing }}
                 </tspan>
@@ -2412,13 +2411,13 @@
                 id="arrow_node4_south_incoming_number_text"
                 xml:space="preserve"
                 transform="scale(0.86707182,1.153307)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2431,7 +2430,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="-1015.5829"
                 y="-86.404541"
               >
@@ -2439,19 +2438,19 @@
                   id="arrow_node4_south_incoming_number_tspan"
                   x="141.44441"
                   y="701.48889"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9482;
-                  "
+                  `"
                 >
                   {{ zaehlwertArrowNodeFourSouthIncoming }}
                 </tspan>
@@ -2464,13 +2463,13 @@
                 id="arrows_node4_south_sum_text"
                 xml:space="preserve"
                 transform="scale(0.86675167,1.153733)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2483,7 +2482,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9644;
-                "
+                `"
                 x="-1015.1211"
                 y="-59.637363"
               >
@@ -2491,19 +2490,19 @@
                   id="arrows_node4_south_sum_tspan"
                   x="142.33362"
                   y="728.54749"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: 28.097px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9644;
-                  "
+                  `"
                 >
                   {{ sumArrowsNodeFourSouth }}
                 </tspan>
@@ -2540,13 +2539,13 @@
                 id="arrow_node4_north_outgoing_number_text"
                 xml:space="preserve"
                 transform="scale(0.86707182,1.153307)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2559,7 +2558,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="-1015.5829"
                 y="-259.38544"
               >
@@ -2567,19 +2566,19 @@
                   id="arrow_node4_north_outgoing_number_tspan"
                   x="141.44441"
                   y="528.50812"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9482;
-                  "
+                  `"
                 >
                   {{ zaehlwertArrowNodeFourNorthOutgoing }}
                 </tspan>
@@ -2589,13 +2588,13 @@
                 id="arrow_node4_north_incoming_number_text"
                 xml:space="preserve"
                 transform="scale(0.86707182,1.153307)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2608,7 +2607,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="-1015.5829"
                 y="-230.55518"
               >
@@ -2616,19 +2615,19 @@
                   id="arrow_node4_north_incoming_number_tspan"
                   x="141.44441"
                   y="557.33826"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9482;
-                  "
+                  `"
                 >
                   {{ zaehlwertArrowNodeFourNorthIncoming }}
                 </tspan>
@@ -2640,14 +2639,13 @@
                 "
                 id="arrows_node4_north_sum_text"
                 xml:space="preserve"
-                transform="scale(0.86675167,1.153733)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2660,7 +2658,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9644;
-                "
+                `"
                 x="-1015.1211"
                 y="-203.7348"
               >
@@ -2668,19 +2666,19 @@
                   id="arrows_node4_north_sum_tspan"
                   x="142.33362"
                   y="584.45007"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: 28.097px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9644;
-                  "
+                  `"
                 >
                   {{ sumArrowsNodeFourNorth }}
                 </tspan>
@@ -2731,16 +2729,16 @@
               <text
                 id="node5_number_text"
                 xml:space="preserve"
-                style="
-                  font-size: 19.7624px;
-                  font-family: sans-serif;
+                :style="`
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
                   direction: ltr;
                   text-anchor: start;
                   fill: #000000;
                   stroke-width: 30.9229;
-                "
+                `"
                 y="646.03784"
                 x="754.23737"
               >
@@ -2758,13 +2756,13 @@
               v-if="streetnameNodeFive.length === 1"
               id="node5_strassenname_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -2778,7 +2776,7 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               transform="rotate(-45)"
               x="28.961178"
               y="919.29749"
@@ -2796,13 +2794,13 @@
               v-if="streetnameNodeFive.length > 1"
               id="node5_strassenname_multirow2_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -2816,7 +2814,7 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               transform="rotate(-45)"
               x="28.963634"
               y="933.29785"
@@ -2834,13 +2832,13 @@
               v-if="streetnameNodeFive.length > 1"
               id="node5_strassenname_multirow1_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -2854,7 +2852,7 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               transform="rotate(-45)"
               x="28.961172"
               y="905.2995"
@@ -2872,13 +2870,13 @@
               id="node5_sum_text"
               xml:space="preserve"
               transform="matrix(0.61288545,-0.61288545,0.81581313,0.81581313,0,0)"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: bold;
                 font-stretch: normal;
-                font-size: 28.097px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -2891,7 +2889,7 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 43.9645;
-              "
+              `"
               x="-399.63812"
               y="79.779076"
             >
@@ -2899,19 +2897,19 @@
                 id="node5_sum_tspan"
                 x="757.8175"
                 y="867.96423"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
                   stroke-width: 43.9645;
-                "
+                `"
               >
                 {{ sumNodeFiveArrows }}
               </tspan>
@@ -2940,13 +2938,13 @@
                 id="arrow_node5_north_west_incoming_number_text"
                 xml:space="preserve"
                 transform="matrix(0.61311236,-0.61311236,0.8155112,0.8155112,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2959,7 +2957,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="-399.20233"
                 y="-7.9779282"
               >
@@ -2967,19 +2965,19 @@
                   id="arrow_node5_north_west_incoming_number_tspan"
                   x="757.82507"
                   y="779.91565"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9482;
-                  "
+                  `"
                 >
                   {{ zaehlwertArrowNodeFiveNorthWestIncoming }}
                 </tspan>
@@ -2989,13 +2987,13 @@
                 id="arrow_node5_north_west_outgoing_number_text"
                 xml:space="preserve"
                 transform="matrix(0.61311236,-0.61311236,0.8155112,0.8155112,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3008,7 +3006,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="-399.20517"
                 y="20.852219"
               >
@@ -3016,19 +3014,19 @@
                   id="arrow_node5_north_west_outgoing_number_tspan"
                   x="757.82214"
                   y="808.74573"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9482;
-                  "
+                  `"
                 >
                   {{ zaehlwertArrowNodeFiveNorthWestOutgoing }}
                 </tspan>
@@ -3041,13 +3039,13 @@
                 id="arrows_node5_north_west_sum_text"
                 xml:space="preserve"
                 transform="matrix(0.61288598,-0.61288598,0.81581243,0.81581243,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3060,7 +3058,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9644;
-                "
+                `"
                 x="-399.64072"
                 y="47.580051"
               >
@@ -3068,19 +3066,19 @@
                   id="arrows_node5_north_west_sum_tspan"
                   x="757.81403"
                   y="835.76489"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: 28.097px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9644;
-                  "
+                  `"
                 >
                   {{ sumArrowsNodeFiveNorthWest }}
                 </tspan>
@@ -3117,13 +3115,13 @@
                 id="arrow_node5_south_east_incoming_number_text"
                 xml:space="preserve"
                 transform="matrix(0.61311236,-0.61311236,0.8155112,0.8155112,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3136,7 +3134,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="-399.20517"
                 y="136.17249"
               >
@@ -3144,19 +3142,19 @@
                   id="arrow_node5_south_east_incoming_number_tspan"
                   x="757.82214"
                   y="924.06604"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9482;
-                  "
+                  `"
                 >
                   {{ zaehlwertArrowNodeFiveSouthEastIncoming }}
                 </tspan>
@@ -3166,13 +3164,13 @@
                 id="arrow_node5_south_east_outgoing_number_text"
                 xml:space="preserve"
                 transform="matrix(0.61311236,-0.61311236,0.8155112,0.8155112,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3185,7 +3183,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="-399.2023"
                 y="165.00262"
               >
@@ -3193,19 +3191,19 @@
                   id="arrow_node5_south_east_outgoing_number_tspan"
                   x="757.82501"
                   y="952.89612"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9482;
-                  "
+                  `"
                 >
                   {{ zaehlwertArrowNodeFiveSouthEastOutgoing }}
                 </tspan>
@@ -3218,13 +3216,13 @@
                 id="arrows_node5_south_east_sum_text"
                 xml:space="preserve"
                 transform="matrix(0.61288598,-0.61288598,0.81581243,0.81581243,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3237,7 +3235,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9644;
-                "
+                `"
                 x="-399.63785"
                 y="191.67722"
               >
@@ -3245,19 +3243,19 @@
                   id="arrows_node5_south_east_sum_tspan"
                   x="757.81683"
                   y="979.86206"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: 28.097px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9644;
-                  "
+                  `"
                 >
                   {{ sumArrowsNodeFiveSouthEast }}
                 </tspan>
@@ -3290,13 +3288,13 @@
               v-if="streetnameNodeSix.length === 1"
               id="node6_strassenname_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -3310,7 +3308,7 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               transform="rotate(45)"
               x="1018.9124"
               y="-70.653908"
@@ -3346,16 +3344,16 @@
               <text
                 id="node6_number_text"
                 xml:space="preserve"
-                style="
-                  font-size: 19.7624px;
-                  font-family: sans-serif;
+                :style="`
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
                   direction: ltr;
                   text-anchor: start;
                   fill: #000000;
                   stroke-width: 30.9229;
-                "
+                `"
                 y="1118.2867"
                 x="29.266506"
                 transform="rotate(-45)"
@@ -3374,13 +3372,13 @@
               v-if="streetnameNodeSix.length > 1"
               id="node6_strassenname_multirow2_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -3394,7 +3392,7 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               transform="rotate(45)"
               x="1018.9124"
               y="-56.65107"
@@ -3412,13 +3410,13 @@
               v-if="streetnameNodeSix.length > 1"
               id="node6_strassenname_multirow1_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -3432,7 +3430,7 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               transform="rotate(45)"
               x="1018.9124"
               y="-84.651787"
@@ -3450,13 +3448,13 @@
               id="node6_sum_text"
               xml:space="preserve"
               transform="matrix(0.61288545,0.61288545,-0.81581313,0.81581313,0,0)"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: bold;
                 font-stretch: normal;
-                font-size: 28.097px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -3469,7 +3467,7 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 43.9645;
-              "
+              `"
               x="742.49854"
               y="-778.25079"
             >
@@ -3477,19 +3475,19 @@
                 id="node6_sum_tspan"
                 x="1899.9543"
                 y="9.9343462"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
                   stroke-width: 43.9645;
-                "
+                `"
               >
                 {{ sumNodeSixArrows }}
               </tspan>
@@ -3518,13 +3516,13 @@
                 id="arrow_node6_north_east_incoming_number_text"
                 xml:space="preserve"
                 transform="matrix(0.61311236,0.61311236,-0.8155112,0.8155112,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3537,7 +3535,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="741.38873"
                 y="-866.33527"
               >
@@ -3545,19 +3543,19 @@
                   id="arrow_node6_north_east_incoming_number_tspan"
                   x="1898.416"
                   y="-78.441635"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9482;
-                  "
+                  `"
                 >
                   {{ zaehlwertArrowNodeSixNorthEastIncoming }}
                 </tspan>
@@ -3567,13 +3565,13 @@
                 id="arrow_node6_north_east_outgoing_number_text"
                 xml:space="preserve"
                 transform="matrix(0.61311236,0.61311236,-0.8155112,0.8155112,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3586,7 +3584,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="741.38599"
                 y="-837.50513"
               >
@@ -3594,19 +3592,19 @@
                   id="arrow_node6_north_east_outgoing_number_tspan"
                   x="1898.4132"
                   y="-49.611588"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9482;
-                  "
+                  `"
                 >
                   {{ zaehlwertArrowNodeSixNorthEastOutgoing }}
                 </tspan>
@@ -3619,13 +3617,13 @@
                 id="arrows_node6_north_east_sum_text"
                 xml:space="preserve"
                 transform="matrix(0.61288598,0.61288598,-0.81581243,0.81581243,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3638,7 +3636,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9644;
-                "
+                `"
                 x="742.49811"
                 y="-810.4613"
               >
@@ -3646,19 +3644,19 @@
                   id="arrows_node6_north_east_sum_tspan"
                   x="1899.9528"
                   y="-22.276493"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: 28.097px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9644;
-                  "
+                  `"
                 >
                   {{ sumArrowsNode6NorthEast }}
                 </tspan>
@@ -3695,13 +3693,13 @@
                 id="arrow_node6_south_west_incoming_number_text"
                 xml:space="preserve"
                 transform="matrix(0.61311236,0.61311236,-0.8155112,0.8155112,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3714,7 +3712,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="741.38593"
                 y="-722.18481"
               >
@@ -3722,19 +3720,19 @@
                   id="arrow_node6_south_west_incoming_number_tspan"
                   x="1898.4132"
                   y="65.708748"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9482;
-                  "
+                  `"
                 >
                   {{ zaehlwertArrowNodeSixSouthWestIncoming }}
                 </tspan>
@@ -3744,13 +3742,13 @@
                 id="arrow_node6_south_west_outgoing_number_text"
                 xml:space="preserve"
                 transform="matrix(0.61311236,0.61311236,-0.8155112,0.8155112,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3763,7 +3761,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="741.38873"
                 y="-693.35468"
               >
@@ -3771,19 +3769,19 @@
                   id="arrow_node6_south_west_outgoing_number_tspan"
                   x="1898.416"
                   y="94.53878"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9482;
-                  "
+                  `"
                 >
                   {{ zaehlwertArrowNodeSixSouthWestOutgoing }}
                 </tspan>
@@ -3796,13 +3794,13 @@
                 id="arrows_node6_south_west_sum_text"
                 xml:space="preserve"
                 transform="matrix(0.61288598,0.61288598,-0.81581243,0.81581243,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3815,7 +3813,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9644;
-                "
+                `"
                 x="742.49805"
                 y="-666.362"
               >
@@ -3823,19 +3821,19 @@
                   id="arrows_node6_south_west_sum_tspan"
                   x="1899.9528"
                   y="121.82278"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: 28.097px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9644;
-                  "
+                  `"
                 >
                   {{ sumArrowsNodeSixSouthWest }}
                 </tspan>
@@ -3868,13 +3866,13 @@
               v-if="streetnameNodeSeven.length === 1"
               id="node7_strassenname_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -3888,26 +3886,26 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               transform="rotate(-45)"
               x="-262.48059"
               y="995.74023"
             >
               <tspan
                 id="node7_strassenname_tspan"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 22.3767px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
                   stroke-width: 26.4927;
-                "
+                `"
                 x="-262.48059"
                 y="995.74023"
               >
@@ -3933,16 +3931,16 @@
               <text
                 id="node7_number_text"
                 xml:space="preserve"
-                style="
-                  font-size: 19.7624px;
-                  font-family: sans-serif;
+                :style="`
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
                   direction: ltr;
                   text-anchor: start;
                   fill: #000000;
                   stroke-width: 30.9229;
-                "
+                `"
                 y="767.69238"
                 x="633.51685"
               >
@@ -3960,13 +3958,13 @@
               v-if="streetnameNodeSeven.length > 1"
               id="node7_strassenname_multirow2_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -3980,26 +3978,26 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               transform="rotate(-45)"
               x="-262.48306"
               y="1009.7406"
             >
               <tspan
                 id="node7_strassenname_multirow2_tspan"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 22.3767px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
                   stroke-width: 26.4927;
-                "
+                `"
                 x="-262.48306"
                 y="1009.7406"
               >
@@ -4010,13 +4008,13 @@
               v-if="streetnameNodeSeven.length > 1"
               id="node7_strassenname_multirow1_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -4030,26 +4028,26 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               transform="rotate(-45)"
               x="-262.48306"
               y="981.73987"
             >
               <tspan
                 id="node7_strassenname_multirow1_tspan"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 22.3767px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
                   stroke-width: 26.4927;
-                "
+                `"
                 x="-262.48306"
                 y="981.73987"
               >
@@ -4060,13 +4058,13 @@
               id="node7_sum_text"
               xml:space="preserve"
               transform="matrix(0.61288545,-0.61288545,0.81581313,0.81581313,0,0)"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: bold;
                 font-stretch: normal;
-                font-size: 28.097px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -4079,7 +4077,7 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 43.9645;
-              "
+              `"
               x="-1822.7341"
               y="79.781219"
             >
@@ -4087,19 +4085,19 @@
                 id="node7_sum_tspan"
                 x="-665.27838"
                 y="867.96637"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
                   stroke-width: 43.9645;
-                "
+                `"
               >
                 {{ sumNodeSevenArrows }}
               </tspan>
@@ -4128,13 +4126,13 @@
                 id="arrow_node7_south_east_outgoing_number_text"
                 xml:space="preserve"
                 transform="matrix(0.61311236,-0.61311236,0.8155112,0.8155112,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4147,7 +4145,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="-1821.7715"
                 y="136.17253"
               >
@@ -4155,19 +4153,19 @@
                   id="arrow_node7_south_east_outgoing_number_tspan"
                   x="-664.74414"
                   y="924.06604"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9482;
-                  "
+                  `"
                 >
                   {{ zaehlwertArrowNodeSevenSouthEastOutgoing }}
                 </tspan>
@@ -4177,13 +4175,13 @@
                 id="arrow_node7_south_east_incoming_number_text"
                 xml:space="preserve"
                 transform="matrix(0.61311236,-0.61311236,0.8155112,0.8155112,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4196,7 +4194,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="-1821.7743"
                 y="165.00264"
               >
@@ -4204,19 +4202,19 @@
                   id="arrow_node7_south_east_incoming_number_tspan"
                   x="-664.74701"
                   y="952.89606"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9482;
-                  "
+                  `"
                 >
                   {{ zaehlwertArrowNodeSevenSouthEastIncoming }}
                 </tspan>
@@ -4229,13 +4227,13 @@
                 id="arrows_node7_south_east_sum_text"
                 xml:space="preserve"
                 transform="matrix(0.61288598,-0.61288598,0.81581243,0.81581243,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4248,7 +4246,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9644;
-                "
+                `"
                 x="-1822.7355"
                 y="191.67723"
               >
@@ -4256,19 +4254,19 @@
                   id="arrows_node7_south_east_sum_tspan"
                   x="-665.28058"
                   y="979.86206"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: 28.097px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9644;
-                  "
+                  `"
                 >
                   {{ sumArrowsNodeSevenSouthEast }}
                 </tspan>
@@ -4305,13 +4303,13 @@
                 id="arrow_node7_north_west_outgoing_number_text"
                 xml:space="preserve"
                 transform="matrix(0.61311236,-0.61311236,0.8155112,0.8155112,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4324,7 +4322,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="-1821.7744"
                 y="-7.9778929"
               >
@@ -4332,19 +4330,19 @@
                   id="arrow_node7_north_west_outgoing_number_tspan"
                   x="-664.74695"
                   y="779.91565"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9482;
-                  "
+                  `"
                 >
                   {{ zaehlwertArrowNodeSevenNorthWestOutgoing }}
                 </tspan>
@@ -4354,13 +4352,13 @@
                 id="arrow_node7_north_west_incoming_number_text"
                 xml:space="preserve"
                 transform="matrix(0.61311236,-0.61311236,0.8155112,0.8155112,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4373,7 +4371,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="-1821.7715"
                 y="20.852285"
               >
@@ -4381,19 +4379,19 @@
                   id="arrow_node7_north_west_incoming_number_tspan"
                   x="-664.74414"
                   y="808.74573"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9482;
-                  "
+                  `"
                 >
                   {{ zaehlwertArrowNodeSevenNorthWestIncoming }}
                 </tspan>
@@ -4406,13 +4404,13 @@
                 id="arrows_node7_north_west_sum_text"
                 xml:space="preserve"
                 transform="matrix(0.61288598,-0.61288598,0.81581243,0.81581243,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4425,7 +4423,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9644;
-                "
+                `"
                 x="-1822.7325"
                 y="47.580002"
               >
@@ -4433,19 +4431,19 @@
                   id="arrows_node7_north_west_sum_tspan"
                   x="-665.27777"
                   y="835.76489"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: 28.097px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9644;
-                  "
+                  `"
                 >
                   {{ sumArrowsNodeSevenNorthWest }}
                 </tspan>
@@ -4478,13 +4476,13 @@
               v-if="streetnameNodeEight.length === 1"
               id="node8_strassenname_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -4498,26 +4496,26 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               x="727.46826"
               y="5.7913613"
               transform="rotate(45)"
             >
               <tspan
                 id="node8_strassenname_tspan"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 22.3767px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
                   stroke-width: 26.4927;
-                "
+                `"
                 x="727.46826"
                 y="5.7913613"
               >
@@ -4543,16 +4541,16 @@
               <text
                 id="node8_number_text"
                 xml:space="preserve"
-                style="
-                  font-size: 19.7624px;
-                  font-family: sans-serif;
+                :style="`
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
                   direction: ltr;
                   text-anchor: start;
                   fill: #000000;
                   stroke-width: 30.9229;
-                "
+                `"
                 y="646.78491"
                 x="633.36969"
               >
@@ -4570,13 +4568,13 @@
               v-if="streetnameNodeEight.length > 1"
               id="node8_strassenname_multirow2_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -4590,26 +4588,26 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               x="727.47076"
               y="19.791721"
               transform="rotate(45)"
             >
               <tspan
                 id="node8_strassenname_multirow2_tspan"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 22.3767px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
                   stroke-width: 26.4927;
-                "
+                `"
                 x="727.47076"
                 y="19.791721"
               >
@@ -4620,13 +4618,13 @@
               v-if="streetnameNodeEight.length > 1"
               id="node8_strassenname_multirow1_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -4640,26 +4638,26 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               x="727.47076"
               y="-8.2089996"
               transform="rotate(45)"
             >
               <tspan
                 id="node8_strassenname_multirow1_tspan"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 22.3767px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
                   stroke-width: 26.4927;
-                "
+                `"
                 x="727.47076"
                 y="-8.2089996"
               >
@@ -4669,14 +4667,13 @@
             <text
               id="node8_sum_text"
               xml:space="preserve"
-              transform="matrix(0.61288598,0.61288598,-0.81581243,0.81581243,0,0)"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: bold;
                 font-stretch: normal;
-                font-size: 28.097px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -4689,7 +4686,7 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 43.9644;
-              "
+              `"
               x="-680.59656"
               y="-778.25226"
             >
@@ -4697,19 +4694,19 @@
                 id="node8_sum_tspan"
                 x="476.85812"
                 y="9.9321899"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
                   stroke-width: 43.9644;
-                "
+                `"
               >
                 {{ sumNodeEightArrows }}
               </tspan>
@@ -4738,13 +4735,13 @@
                 id="arrow_node8_south_west_outgoing_number_text"
                 xml:space="preserve"
                 transform="matrix(0.61311236,0.61311236,-0.8155112,0.8155112,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4757,7 +4754,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="-681.18036"
                 y="-722.18488"
               >
@@ -4765,19 +4762,19 @@
                   id="arrow_node8_south_west_outgoing_number_tspan"
                   x="475.84692"
                   y="65.708733"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9482;
-                  "
+                  `"
                 >
                   {{ zaehlwertArrowNodeEightSouthWestOutgoing }}
                 </tspan>
@@ -4787,13 +4784,13 @@
                 id="arrow_node8_south_west_incoming_number_text"
                 xml:space="preserve"
                 transform="matrix(0.61311236,0.61311236,-0.8155112,0.8155112,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4806,7 +4803,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="-681.18329"
                 y="-693.35461"
               >
@@ -4814,19 +4811,19 @@
                   id="arrow_node8_south_west_incoming_number_tspan"
                   x="475.84406"
                   y="94.538795"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9482;
-                  "
+                  `"
                 >
                   {{ zaehlwertArrowNodeEightSouthWestIncoming }}
                 </tspan>
@@ -4839,13 +4836,13 @@
                 id="arrows_node8_south_west_sum_text"
                 xml:space="preserve"
                 transform="matrix(0.61288598,0.61288598,-0.81581243,0.81581243,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4858,7 +4855,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9644;
-                "
+                `"
                 x="-680.59656"
                 y="-666.3642"
               >
@@ -4866,19 +4863,19 @@
                   id="arrows_node8_south_west_sum_tspan"
                   x="476.85815"
                   y="121.82064"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: 28.097px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9644;
-                  "
+                  `"
                 >
                   {{ sumArrowsNodeEightSouthWest }}
                 </tspan>
@@ -4915,13 +4912,13 @@
                 id="arrow_node8_north_east_outgoing_number_text"
                 xml:space="preserve"
                 transform="matrix(0.61311236,0.61311236,-0.8155112,0.8155112,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4934,7 +4931,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="-681.18323"
                 y="-866.33521"
               >
@@ -4942,19 +4939,19 @@
                   id="arrow_node8_north_east_outgoing_number_tspan"
                   x="475.84406"
                   y="-78.441643"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9482;
-                  "
+                  `"
                 >
                   {{ zaehlwertArrowNodeEightNorthEastOutgoing }}
                 </tspan>
@@ -4964,13 +4961,13 @@
                 id="arrow_node8_north_east_incoming_number_text"
                 xml:space="preserve"
                 transform="matrix(0.61311236,0.61311236,-0.8155112,0.8155112,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4983,7 +4980,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="-681.18036"
                 y="-837.505"
               >
@@ -4991,19 +4988,19 @@
                   id="arrow_node8_north_east_incoming_number_tspan"
                   x="475.84692"
                   y="-49.611568"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9482;
-                  "
+                  `"
                 >
                   {{ zaehlwertArrowNodeEightNorthEastIncoming }}
                 </tspan>
@@ -5016,13 +5013,13 @@
                 id="arrows_node8_north_east_sum_text"
                 xml:space="preserve"
                 transform="matrix(0.61288598,0.61288598,-0.81581243,0.81581243,0,0)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -5035,7 +5032,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9644;
-                "
+                `"
                 x="-680.59656"
                 y="-810.45923"
               >
@@ -5043,19 +5040,19 @@
                   id="arrows_node8_north_east_sum_tspan"
                   x="476.85815"
                   y="-22.274359"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: 28.097px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 43.9644;
-                  "
+                  `"
                 >
                   {{ sumArrowsNodeEightNorthEast }}
                 </tspan>
@@ -5103,6 +5100,7 @@ import Zeitblock, { zeitblockInfo } from "@/types/enum/Zeitblock";
 import { zeitblockStuendlichInfo } from "@/types/enum/ZeitblockStuendlich";
 import { useDateUtils } from "@/util/DateUtils";
 import { useFjs } from "@/util/FjsUtils";
+import {useBelastungsplanMethods} from "@/components/zaehlstelle/charts/BelastungsplanMethods";
 
 interface Props {
   data: LadeBelastungsplanDTO;
@@ -5121,6 +5119,7 @@ const zaehlstelleStore = useZaehlstelleStore();
 const display = useDisplay();
 const dateUtils = useDateUtils();
 const fjs = useFjs();
+const belastungsplanMethods = useBelastungsplanMethods();
 
 const streetnameNodeOne = ref<Array<string>>([]);
 const streetnameNodeTwo = ref<Array<string>>([]);

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanFjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanFjsSvg.vue
@@ -33,7 +33,7 @@
               font-weight: normal;
               font-stretch: normal;
               font-size: ${belastungsplanMethods.maxlineWidth};
-              family: ${BelastungsplanConstants.fontfamily};
+              font-family: ${BelastungsplanConstants.fontfamily};
               font-variant-ligatures: normal;
               font-variant-caps: normal;
               font-variant-numeric: normal;
@@ -80,7 +80,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth};
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -121,7 +121,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -184,7 +184,7 @@
               font-weight: normal;
               font-stretch: normal;
               font-size: ${belastungsplanMethods.maxlineWidth}px;
-              family: ${BelastungsplanConstants.fontfamily};
+              font-family: ${BelastungsplanConstants.fontfamily};
               font-variant-ligatures: normal;
               font-variant-caps: normal;
               font-variant-numeric: normal;
@@ -207,7 +207,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -238,7 +238,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -294,7 +294,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -368,7 +368,7 @@
                 xml:space="default"
                 :style="`
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
                   direction: ltr;
@@ -399,7 +399,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -437,7 +437,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -475,7 +475,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -513,7 +513,7 @@
                 font-weight: bold;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -540,7 +540,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -581,7 +581,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -608,7 +608,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -630,7 +630,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -657,7 +657,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -682,7 +682,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -709,7 +709,7 @@
                     font-weight: bold;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -758,7 +758,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -785,7 +785,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -807,7 +807,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -834,7 +834,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -859,7 +859,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -886,7 +886,7 @@
                     font-weight: bold;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -931,7 +931,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -979,7 +979,7 @@
                 xml:space="default"
                 :style="`
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
                   direction: ltr;
@@ -1010,7 +1010,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -1047,7 +1047,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -1084,7 +1084,7 @@
                 font-weight: bold;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -1111,7 +1111,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1152,7 +1152,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1179,7 +1179,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -1201,7 +1201,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1228,7 +1228,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -1253,7 +1253,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1280,7 +1280,7 @@
                     font-weight: bold;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -1329,7 +1329,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1356,7 +1356,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -1378,7 +1378,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1405,7 +1405,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -1430,7 +1430,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1457,7 +1457,7 @@
                     font-weight: bold;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -1502,7 +1502,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -1529,7 +1529,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1563,7 +1563,7 @@
                 xml:space="default"
                 :style="`
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
                   direction: ltr;
@@ -1594,7 +1594,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -1621,7 +1621,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1644,7 +1644,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -1671,7 +1671,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1694,7 +1694,7 @@
                 font-weight: bold;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -1721,7 +1721,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1762,7 +1762,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1789,7 +1789,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -1811,7 +1811,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1838,7 +1838,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -1863,7 +1863,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1890,7 +1890,7 @@
                     font-weight: bold;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -1939,7 +1939,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1966,7 +1966,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -1988,7 +1988,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2015,7 +2015,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -2040,7 +2040,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2067,7 +2067,7 @@
                     font-weight: bold;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -2112,7 +2112,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -2138,7 +2138,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2172,7 +2172,7 @@
                 xml:space="default"
                 :style="`
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
                   direction: ltr;
@@ -2203,7 +2203,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -2229,7 +2229,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2252,7 +2252,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -2278,7 +2278,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2300,7 +2300,7 @@
                 font-weight: bold;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -2327,7 +2327,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2368,7 +2368,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2395,7 +2395,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -2417,7 +2417,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2444,7 +2444,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -2469,7 +2469,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2496,7 +2496,7 @@
                     font-weight: bold;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -2545,7 +2545,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2572,7 +2572,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -2594,7 +2594,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2621,7 +2621,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -2645,7 +2645,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2672,7 +2672,7 @@
                     font-weight: bold;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -2731,7 +2731,7 @@
                 xml:space="default"
                 :style="`
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
                   direction: ltr;
@@ -2762,7 +2762,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -2800,7 +2800,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -2838,7 +2838,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -2876,7 +2876,7 @@
                 font-weight: bold;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -2903,7 +2903,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2944,7 +2944,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2971,7 +2971,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -2993,7 +2993,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3020,7 +3020,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -3045,7 +3045,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3072,7 +3072,7 @@
                     font-weight: bold;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -3121,7 +3121,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3148,7 +3148,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -3170,7 +3170,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3197,7 +3197,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -3222,7 +3222,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3249,7 +3249,7 @@
                     font-weight: bold;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -3294,7 +3294,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -3346,7 +3346,7 @@
                 xml:space="default"
                 :style="`
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
                   direction: ltr;
@@ -3378,7 +3378,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -3416,7 +3416,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -3454,7 +3454,7 @@
                 font-weight: bold;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -3481,7 +3481,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3522,7 +3522,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3549,7 +3549,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -3571,7 +3571,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3598,7 +3598,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -3623,7 +3623,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3650,7 +3650,7 @@
                     font-weight: bold;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -3699,7 +3699,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3726,7 +3726,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -3748,7 +3748,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3775,7 +3775,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -3800,7 +3800,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3827,7 +3827,7 @@
                     font-weight: bold;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -3872,7 +3872,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -3899,7 +3899,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -3933,7 +3933,7 @@
                 xml:space="default"
                 :style="`
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
                   direction: ltr;
@@ -3964,7 +3964,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -3991,7 +3991,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4014,7 +4014,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -4041,7 +4041,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4064,7 +4064,7 @@
                 font-weight: bold;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -4091,7 +4091,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4132,7 +4132,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4159,7 +4159,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -4181,7 +4181,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4208,7 +4208,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -4233,7 +4233,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4260,7 +4260,7 @@
                     font-weight: bold;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -4309,7 +4309,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4336,7 +4336,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -4358,7 +4358,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4385,7 +4385,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -4410,7 +4410,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4437,7 +4437,7 @@
                     font-weight: bold;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -4482,7 +4482,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -4509,7 +4509,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4543,7 +4543,7 @@
                 xml:space="default"
                 :style="`
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
                   direction: ltr;
@@ -4574,7 +4574,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -4601,7 +4601,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4624,7 +4624,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -4651,7 +4651,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4673,7 +4673,7 @@
                 font-weight: bold;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                family: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -4700,7 +4700,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4741,7 +4741,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4768,7 +4768,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -4790,7 +4790,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4817,7 +4817,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -4842,7 +4842,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4869,7 +4869,7 @@
                     font-weight: bold;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -4918,7 +4918,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4945,7 +4945,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -4967,7 +4967,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -4994,7 +4994,7 @@
                     font-weight: normal;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
@@ -5019,7 +5019,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  family: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -5046,7 +5046,7 @@
                     font-weight: bold;
                     font-stretch: normal;
                     font-size: ${belastungsplanMethods.maxlineWidth}px;
-                    family: ${BelastungsplanConstants.fontfamily};
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanFjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanFjsSvg.vue
@@ -120,7 +120,7 @@
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -183,7 +183,7 @@
               font-variant: normal;
               font-weight: normal;
               font-stretch: normal;
-              font-size: ${belastungsplanMethods.maxlineWidth};
+              font-size: ${belastungsplanMethods.maxlineWidth}px;
               font-familiy: ${BelastungsplanConstants.fontfamily};
               font-variant-ligatures: normal;
               font-variant-caps: normal;
@@ -206,7 +206,7 @@
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -237,7 +237,7 @@
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -293,7 +293,7 @@
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -367,7 +367,7 @@
                 id="node1_circle_text"
                 xml:space="preserve"
                 :style="`
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
@@ -398,7 +398,7 @@
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -436,7 +436,7 @@
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -474,7 +474,7 @@
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -512,7 +512,7 @@
                 font-variant: normal;
                 font-weight: bold;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -539,7 +539,7 @@
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -580,7 +580,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -607,7 +607,7 @@
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -629,7 +629,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -656,7 +656,7 @@
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -681,7 +681,7 @@
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -708,7 +708,7 @@
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -757,7 +757,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -784,7 +784,7 @@
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -806,7 +806,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -833,7 +833,7 @@
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -858,7 +858,7 @@
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -885,7 +885,7 @@
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -930,7 +930,7 @@
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -978,7 +978,7 @@
                 id="node2_number_text"
                 xml:space="preserve"
                 :style="`
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
@@ -1009,7 +1009,7 @@
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -1046,7 +1046,7 @@
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -1083,7 +1083,7 @@
                 font-variant: normal;
                 font-weight: bold;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -1110,7 +1110,7 @@
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -1151,7 +1151,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -1178,7 +1178,7 @@
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -1200,7 +1200,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -1227,7 +1227,7 @@
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -1252,7 +1252,7 @@
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -1279,7 +1279,7 @@
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -1328,7 +1328,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -1355,7 +1355,7 @@
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -1377,7 +1377,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -1404,7 +1404,7 @@
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -1429,7 +1429,7 @@
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -1456,7 +1456,7 @@
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -1501,7 +1501,7 @@
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -1528,7 +1528,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -1562,7 +1562,7 @@
                 id="node3_number_text"
                 xml:space="preserve"
                 :style="`
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
@@ -1593,7 +1593,7 @@
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -1620,7 +1620,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -1643,7 +1643,7 @@
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -1670,7 +1670,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -1693,7 +1693,7 @@
                 font-variant: normal;
                 font-weight: bold;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -1720,7 +1720,7 @@
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -1761,7 +1761,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -1788,7 +1788,7 @@
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -1810,7 +1810,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -1837,7 +1837,7 @@
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -1862,7 +1862,7 @@
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -1889,7 +1889,7 @@
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -1938,7 +1938,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -1965,7 +1965,7 @@
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -1987,7 +1987,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -2014,7 +2014,7 @@
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -2039,7 +2039,7 @@
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -2066,7 +2066,7 @@
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -2111,7 +2111,7 @@
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -2137,7 +2137,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -2171,7 +2171,7 @@
                 id="node4_number_text"
                 xml:space="preserve"
                 :style="`
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
@@ -2202,7 +2202,7 @@
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -2228,7 +2228,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -2251,7 +2251,7 @@
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -2277,7 +2277,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -2299,7 +2299,7 @@
                 font-variant: normal;
                 font-weight: bold;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -2326,7 +2326,7 @@
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -2367,7 +2367,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -2394,7 +2394,7 @@
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -2416,7 +2416,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -2443,7 +2443,7 @@
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -2468,7 +2468,7 @@
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -2495,7 +2495,7 @@
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -2544,7 +2544,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -2571,7 +2571,7 @@
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -2593,7 +2593,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -2620,7 +2620,7 @@
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -2644,7 +2644,7 @@
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -2671,7 +2671,7 @@
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -2730,7 +2730,7 @@
                 id="node5_number_text"
                 xml:space="preserve"
                 :style="`
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
@@ -2761,7 +2761,7 @@
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -2799,7 +2799,7 @@
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -2837,7 +2837,7 @@
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -2875,7 +2875,7 @@
                 font-variant: normal;
                 font-weight: bold;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -2902,7 +2902,7 @@
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -2943,7 +2943,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -2970,7 +2970,7 @@
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -2992,7 +2992,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -3019,7 +3019,7 @@
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -3044,7 +3044,7 @@
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -3071,7 +3071,7 @@
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -3120,7 +3120,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -3147,7 +3147,7 @@
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -3169,7 +3169,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -3196,7 +3196,7 @@
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -3221,7 +3221,7 @@
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -3248,7 +3248,7 @@
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -3293,7 +3293,7 @@
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -3345,7 +3345,7 @@
                 id="node6_number_text"
                 xml:space="preserve"
                 :style="`
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
@@ -3377,7 +3377,7 @@
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -3415,7 +3415,7 @@
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -3453,7 +3453,7 @@
                 font-variant: normal;
                 font-weight: bold;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -3480,7 +3480,7 @@
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -3521,7 +3521,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -3548,7 +3548,7 @@
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -3570,7 +3570,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -3597,7 +3597,7 @@
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -3622,7 +3622,7 @@
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -3649,7 +3649,7 @@
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -3698,7 +3698,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -3725,7 +3725,7 @@
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -3747,7 +3747,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -3774,7 +3774,7 @@
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -3799,7 +3799,7 @@
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -3826,7 +3826,7 @@
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -3871,7 +3871,7 @@
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -3898,7 +3898,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -3932,7 +3932,7 @@
                 id="node7_number_text"
                 xml:space="preserve"
                 :style="`
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
@@ -3963,7 +3963,7 @@
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -3990,7 +3990,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -4013,7 +4013,7 @@
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -4040,7 +4040,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -4063,7 +4063,7 @@
                 font-variant: normal;
                 font-weight: bold;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -4090,7 +4090,7 @@
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -4131,7 +4131,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -4158,7 +4158,7 @@
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -4180,7 +4180,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -4207,7 +4207,7 @@
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -4232,7 +4232,7 @@
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -4259,7 +4259,7 @@
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -4308,7 +4308,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -4335,7 +4335,7 @@
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -4357,7 +4357,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -4384,7 +4384,7 @@
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -4409,7 +4409,7 @@
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -4436,7 +4436,7 @@
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -4481,7 +4481,7 @@
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -4508,7 +4508,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -4542,7 +4542,7 @@
                 id="node8_number_text"
                 xml:space="preserve"
                 :style="`
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
@@ -4573,7 +4573,7 @@
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -4600,7 +4600,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -4623,7 +4623,7 @@
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -4650,7 +4650,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -4672,7 +4672,7 @@
                 font-variant: normal;
                 font-weight: bold;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -4699,7 +4699,7 @@
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -4740,7 +4740,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -4767,7 +4767,7 @@
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -4789,7 +4789,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -4816,7 +4816,7 @@
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -4841,7 +4841,7 @@
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -4868,7 +4868,7 @@
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -4917,7 +4917,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -4944,7 +4944,7 @@
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -4966,7 +4966,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -4993,7 +4993,7 @@
                     font-variant: normal;
                     font-weight: normal;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
@@ -5018,7 +5018,7 @@
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -5045,7 +5045,7 @@
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: ${belastungsplanMethods.maxlineWidth};
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
                     font-familiy: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanKreuzungSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanKreuzungSvg.vue
@@ -299,7 +299,7 @@ function legendeNordPfeil() {
                   z`;
   nord
     .path(path)
-    .stroke({ width: 2, color: belastungsplanMethods.legendColor })
+    .stroke({ width: 2, color: BelastungsplanConstants.legendColor })
     .attr("fill", "none");
 
   nord
@@ -313,7 +313,7 @@ function legendeNordPfeil() {
       family: BelastungsplanConstants.fontfamily,
       size: belastungsplanMethods.maxlineWidth,
       anchor: "middle",
-      fill: belastungsplanMethods.legendColor,
+      fill: BelastungsplanConstants.legendColor,
     });
 }
 
@@ -526,7 +526,7 @@ function legendeLinienStaerke() {
 
   size
     .path(path)
-    .stroke({ width: 2, color: belastungsplanMethods.legendColor })
+    .stroke({ width: 2, color: BelastungsplanConstants.legendColor })
     .attr("fill", "none");
 
   const path2 = `M${startX + 1.5 * belastungsplanMethods.spalt.value} ${startY}
@@ -535,7 +535,7 @@ function legendeLinienStaerke() {
                    }`;
   size
     .path(path2)
-    .stroke({ width: 2, color: belastungsplanMethods.legendColor })
+    .stroke({ width: 2, color: BelastungsplanConstants.legendColor })
     .attr("fill", "none");
 
   const high =

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanMethods.ts
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanMethods.ts
@@ -61,7 +61,6 @@ export function useBelastungsplanMethods() {
   const maxlineWidth = 20;
   const maxLegendLineWidth = 25;
   const shadowColor = "#E0E0E0";
-  const legendColor = "#757575";
   // Prozentwerte um die Strecken zu errechnen
   const prozentDiagram = 0.6;
   const prozentSpalt = 0.05;
@@ -1504,7 +1503,6 @@ export function useBelastungsplanMethods() {
     chartPosition,
     spalt,
     ecke,
-    legendColor,
     maxlineWidth,
     maxLegendLineWidth,
     maxFahrtrichtungWidth,

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
@@ -969,7 +969,7 @@ function computeAnchorY(el: SVGGraphicsElement | null) {
 }
 
 function scaleTransform(scaleY: number, centerY: number) {
-  if (!Number.isFinite(scaleY) || scaleY === 1) return null;
+  if (!Number.isFinite(scaleY) || scaleY === 1) return undefined;
   return `translate(0 ${centerY}) scale(1 ${scaleY}) translate(0 ${-centerY})`;
 }
 

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
@@ -25,14 +25,13 @@
               <text
                 v-if="firstStreetname.length === 1"
                 xml:space="preserve"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 24.6944px;
-                  font-family: Roboto, Arial, Helvetica, sans-serif;
-                  -inkscape-font-specification: &quot;sans-serif, Normal&quot;;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -43,7 +42,7 @@
                   text-anchor: middle;
                   fill: #000000;
                   stroke-width: 39.1848;
-                "
+                `"
                 x="697.23627"
                 y="704.51794"
                 id="singlerow"
@@ -59,14 +58,13 @@
               <text
                 v-if="firstStreetname.length > 1"
                 xml:space="preserve"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 24.6944px;
-                  font-family: Roboto, Arial, Helvetica, sans-serif;
-                  -inkscape-font-specification: &quot;sans-serif, Normal&quot;;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -77,7 +75,7 @@
                   text-anchor: middle;
                   fill: #000000;
                   stroke-width: 39.1848;
-                "
+                `"
                 id="multirow"
                 x="699.24969"
                 y="688.33734"
@@ -100,14 +98,12 @@
             </g>
           </g>
           <g id="arrows">
-            <g
-                id="arrow4"
-                ref="groupRefArrowFour"
-            >
+            <g id="arrow4">
               <path
                 style="stroke-width: 40.1798"
                 :d="dArrowFour"
                 id="shaft4"
+                ref="groupRefArrowFour"
                 :fill="colorArrowFour"
                 :transform="transformArrowFour"
               />
@@ -123,14 +119,12 @@
                 d="m 1178.1774,846.90543 -18.6954,-22.33904 -0.017,44.62008 z"
               />
             </g>
-            <g
-                id="arrow3"
-                ref="groupRefArrowThree"
-            >
+            <g id="arrow3">
               <path
                 style="stroke-width: 40.1798"
                 :d="dArrowThree"
                 id="shaft3"
+                ref="groupRefArrowThree"
                 :fill="colorArrowThree"
                 :transform="transformArrowThree"
               />
@@ -146,14 +140,12 @@
                 d="m 221.49329,791.09394 19.39305,-22.32164 0.0169,44.58532 z"
               />
             </g>
-            <g
-                id="arrow2"
-                ref="groupRefArrowTwo"
-            >
+            <g id="arrow2">
               <path
                 style="stroke-width: 40.1708"
                 :d="dArrowTwo"
                 id="shaft2"
+                ref="groupRefArrowTwo"
                 :fill="colorArrowTwo"
                 :transform="transformArrowTwo"
               />
@@ -169,14 +161,12 @@
                 d="m 1178.1206,609.06771 -18.7975,-22.45207 -0.017,44.84587 z"
               />
             </g>
-            <g
-                id="arrow1"
-                ref="groupRefArrowOne"
-            >
+            <g id="arrow1">
               <path
                 style="stroke-width: 40.1656"
                 :d="dArrowOne"
                 id="shaft1"
+                ref="groupRefArrowOne"
                 :fill="colorArrowOne"
                 :transform="transformArrowOne"
               />
@@ -198,14 +188,13 @@
               <text
                 xml:space="preserve"
                 id="zaehlwertArrowThree"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 24.6944px;
-                  font-family:Roboto, Arial, Helvetica, sans-serif;
-                  -inkscape-font-specification: &quot;Arial, Normal&quot;;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -218,7 +207,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="1298.7062"
                 y="799.76965"
               >
@@ -233,14 +222,13 @@
               <text
                 xml:space="preserve"
                 id="zaehlwertArrowFour"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 24.6944px;
-                  font-family:Roboto, Arial, Helvetica, sans-serif;
-                  -inkscape-font-specification: &quot;Arial, Normal&quot;;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -253,7 +241,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="1298.0775"
                 y="855.68152"
               >
@@ -273,14 +261,13 @@
               <text
                 xml:space="preserve"
                 id="sumArrowsThreeFour"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 24.6944px;
-                  font-family:Roboto, Arial, Helvetica, sans-serif;
-                  -inkscape-font-specification: &quot;Arial, Bold&quot;;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -293,7 +280,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9644;
-                "
+                `"
                 x="1298.6099"
                 y="884.09052"
               >
@@ -310,14 +297,13 @@
               <text
                 xml:space="preserve"
                 id="zaehlwertArrowOne"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 24.6944px;
-                  font-family:Roboto, Arial, Helvetica, sans-serif;
-                  -inkscape-font-specification: &quot;Arial, Normal&quot;;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -330,7 +316,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="158.24681"
                 y="562.0257"
               >
@@ -339,7 +325,7 @@
                   x="158.24681"
                   y="562.0257"
                 >
-                  123456
+                  {{ zaehlwertArrowOne }}
                 </tspan>
               </text>
               <path
@@ -350,14 +336,13 @@
               <text
                 xml:space="preserve"
                 id="zaehlwertArrowTwo"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 24.6944px;
-                  font-family:Roboto, Arial, Helvetica, sans-serif;
-                  -inkscape-font-specification: &quot;Arial, Normal&quot;;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -370,7 +355,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9482;
-                "
+                `"
                 x="158.83165"
                 y="615.81903"
               >
@@ -379,20 +364,19 @@
                   x="158.83165"
                   y="615.81903"
                 >
-                  123456
+                  {{ zaehlwertArrowTwo }}
                 </tspan>
               </text>
               <text
                 xml:space="preserve"
                 id="sumArrowsOneTwo"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 24.6944px;
-                  font-family:Roboto, Arial, Helvetica, sans-serif;
-                  -inkscape-font-specification: &quot;Arial, Bold&quot;;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-family: ${belastungsplanMethods.maxlineWidth};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -405,7 +389,7 @@
                   fill: #000000;
                   fill-opacity: 1;
                   stroke-width: 43.9644;
-                "
+                `"
                 x="158.26794"
                 y="642.70013"
               >
@@ -421,14 +405,13 @@
             <text
               xml:space="preserve"
               id="sumArrowsOneToFourRight"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: bold;
                 font-stretch: normal;
-                font-size: 24.6944px;
-                font-family:Roboto, Arial, Helvetica, sans-serif;
-                -inkscape-font-specification: &quot;Arial, Bold&quot;;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -441,7 +424,7 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 43.9644;
-              "
+              `"
               x="1297.9579"
               y="708.37695"
             >
@@ -456,14 +439,13 @@
             <text
               xml:space="preserve"
               id="sumArrowsOneToFourLeft"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: bold;
                 font-stretch: normal;
-                font-size: 24.6944px;
-                font-family:Roboto, Arial, Helvetica, sans-serif;
-                -inkscape-font-specification: &quot;Arial, Bold&quot;;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -476,7 +458,7 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 43.9644;
-              "
+              `"
               x="158.22824"
               y="707.44586"
             >
@@ -498,14 +480,13 @@
           >
             <text
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 19.7556px;
-                font-family: Roboto, Arial, Helvetica, sans-serif;
-                -inkscape-font-specification: &quot;Sans, Normal&quot;;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -520,7 +501,7 @@
                 fill: #000000;
                 stroke-width: 28.2205;
                 stroke-dasharray: none;
-              "
+              `"
               id="verkehrsart"
               x="168.24969"
               y="1230.3373"
@@ -532,10 +513,7 @@
                 id="tspan2"
               >
                 <tspan
-                  style="
-                    font-weight: bold;
-                    -inkscape-font-specification: &quot;Sans Bold&quot;;
-                  "
+                  style="font-weight: bold"
                   id="tspan1"
                 >
                   {{ optionen.radverkehr ? "RAD" : "FUSS" }}
@@ -549,14 +527,13 @@
             >
               <text
                 xml:space="preserve"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 19.7556px;
-                  font-family: Roboto, Arial, Helvetica, sans-serif;
-                  -inkscape-font-specification: &quot;Sans, Normal&quot;;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -571,7 +548,7 @@
                   fill: #000000;
                   stroke-width: 28.2205;
                   stroke-dasharray: none;
-                "
+                `"
                 id="zaehlzeit2-multirow"
                 x="168"
                 y="1210"
@@ -591,14 +568,13 @@
             >
               <text
                 xml:space="preserve"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 19.7556px;
-                  font-family: Roboto, Arial, Helvetica, sans-serif;
-                  -inkscape-font-specification: &quot;Sans, Normal&quot;;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -613,7 +589,7 @@
                   fill: #000000;
                   stroke-width: 28.2205;
                   stroke-dasharray: none;
-                "
+                `"
                 id="zaehlzeit1-multirow"
                 x="168.24969"
                 y="1190.3373"
@@ -625,10 +601,7 @@
                   id="tspan5"
                 >
                   <tspan
-                    style="
-                      font-weight: bold;
-                      -inkscape-font-specification: &quot;Sans Bold&quot;;
-                    "
+                    style="font-weight: bold"
                     id="tspan4"
                   >
                     {{ optionen.zeitauswahl }}
@@ -659,14 +632,13 @@
             <text
               xml:space="preserve"
               id="compass1"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 24.6944px;
+                font-size: ${belastungsplanMethods.maxlineWidth};
                 font-family: RomanD;
-                -inkscape-font-specification: &quot;RomanD, Normal&quot;;
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -677,25 +649,24 @@
                 text-anchor: start;
                 fill: #000000;
                 stroke-width: 2.2868;
-              "
+              `"
               x="141.28348"
               y="93.924416"
             >
               <tspan
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 24.6944px;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
                   font-family: RomanD;
-                  -inkscape-font-specification: &quot;RomanD, Normal&quot;;
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
                   stroke-width: 2.2868;
-                "
+                `"
                 id="tspan6"
               >
                 N
@@ -713,14 +684,13 @@
             >
               <text
                 xml:space="preserve"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: 28.6128px;
-                  font-family: Roboto, Arial, Helvetica, sans-serif;
-                  -inkscape-font-specification: &quot;Sans, Normal&quot;;
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -735,7 +705,7 @@
                   fill: #000000;
                   stroke-width: 28.2205;
                   stroke-dasharray: none;
-                "
+                `"
                 id="massstab-size1-multirow"
                 x="699.24969"
                 y="688.33734"
@@ -757,14 +727,13 @@
             >
               <text
                 xml:space="preserve"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: 28.6128px;
-                  font-family: Roboto, Arial, Helvetica, sans-serif;
-                  -inkscape-font-specification: &quot;Sans, Normal&quot;;
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -779,7 +748,7 @@
                   fill: #000000;
                   stroke-width: 28.2205;
                   stroke-dasharray: none;
-                "
+                `"
                 id="massstab-size2-multirow"
                 x="699.24969"
                 y="688.33734"
@@ -831,14 +800,13 @@
               <text
                 v-if="zaehlstelleStore.getZaehlstelleHeader.stadtbezirkNummer"
                 xml:space="preserve"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 19.7556px;
-                  font-family: Roboto, Arial, Helvetica, sans-serif;
-                  -inkscape-font-specification: &quot;Sans, Normal&quot;;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -853,7 +821,7 @@
                   fill: #000000;
                   stroke-width: 28.2205;
                   stroke-dasharray: none;
-                "
+                `"
                 id="zaehlstelle2-multirow"
                 x="699.24969"
                 y="688.33734"
@@ -888,14 +856,13 @@
             >
               <text
                 xml:space="preserve"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 19.7556px;
-                  font-family: Roboto, Arial, Helvetica, sans-serif;
-                  -inkscape-font-specification: &quot;Sans, Normal&quot;;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -910,7 +877,7 @@
                   fill: #000000;
                   stroke-width: 28.2205;
                   stroke-dasharray: none;
-                "
+                `"
                 id="zaehlstelle1-multirow"
                 x="699.24969"
                 y="688.33734"
@@ -922,10 +889,7 @@
                   id="tspan12"
                 >
                   <tspan
-                    style="
-                      font-weight: bold;
-                      -inkscape-font-specification: &quot;Sans Bold&quot;;
-                    "
+                    style="font-weight: bold"
                     id="tspan11"
                   >
                     Zählstelle
@@ -954,6 +918,7 @@ import { computed, nextTick, onMounted, ref, watch } from "vue";
 import { useDisplay } from "vuetify";
 
 import { BelastungsplanConstants } from "@/components/zaehlstelle/charts/BelastungsplanConstants";
+import { useBelastungsplanMethods } from "@/components/zaehlstelle/charts/BelastungsplanMethods";
 import { useZaehlstelleStore } from "@/store/ZaehlstelleStore";
 import BelastungsplanTyp from "@/types/enum/BelastungsplanTyp";
 import Himmelsrichtung from "@/types/enum/Himmelsrichtung";
@@ -983,6 +948,7 @@ const display = useDisplay();
 const dateUtils = useDateUtils();
 const qjs = useQjs();
 const streetnameUtils = useStreetname();
+const belastungsplanMethods = useBelastungsplanMethods();
 
 const firstStreetname = ref<Array<string>>([]);
 const svgRef = ref<SVGSVGElement | null>(null);

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
@@ -480,7 +480,7 @@
         <g id="legend">
           <g id="legend-compass">
             <text
-              xml:space="preserve"
+              xml:space="default"
               id="compass1"
               :style="`
                 font-style: normal;

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
@@ -90,7 +90,7 @@
                 <tspan
                   id="tspan20"
                   x="699.24969"
-                  y="719.49121"
+                  y="713.56885"
                 >
                   {{ firstStreetname[1] }}
                 </tspan>
@@ -100,44 +100,44 @@
           <g id="arrows">
             <g id="arrow1">
               <path
-                  style="stroke-width: 40.1656"
-                  :d="dArrowOne"
-                  id="shaft1"
-                  ref="groupRefArrowOne"
-                  :fill="colorArrowOne"
-                  :transform="transformArrowOne"
+                style="stroke-width: 40.1656"
+                :d="dArrowOne"
+                id="shaft1"
+                ref="groupRefArrowOne"
+                :fill="colorArrowOne"
+                :transform="transformArrowOne"
               />
               <path
-                  style="
+                style="
                   fill: none;
                   stroke: #000000;
                   stroke-width: 2.08902;
                   stroke-dasharray: none;
                   stroke-opacity: 1;
                 "
-                  id="tip1"
-                  d="m 221.73348,553.05942 19.31149,-25.58133 0.0167,51.09625 z"
+                id="tip1"
+                d="m 221.73348,553.05942 19.31149,-25.58133 0.0167,51.09625 z"
               />
             </g>
             <g id="arrow2">
               <path
-                  style="stroke-width: 40.1708"
-                  :d="dArrowTwo"
-                  id="shaft2"
-                  ref="groupRefArrowTwo"
-                  :fill="colorArrowTwo"
-                  :transform="transformArrowTwo"
+                style="stroke-width: 40.1708"
+                :d="dArrowTwo"
+                id="shaft2"
+                ref="groupRefArrowTwo"
+                :fill="colorArrowTwo"
+                :transform="transformArrowTwo"
               />
               <path
-                  style="
+                style="
                   fill: none;
                   stroke: #000000;
                   stroke-width: 1.75545;
                   stroke-dasharray: none;
                   stroke-opacity: 1;
                 "
-                  id="tip2"
-                  d="m 1178.1206,609.06771 -18.7975,-22.45207 -0.017,44.84587 z"
+                id="tip2"
+                d="m 1178.1206,609.06771 -18.7975,-22.45207 -0.017,44.84587 z"
               />
             </g>
             <g id="arrow3">
@@ -163,31 +163,31 @@
             </g>
             <g id="arrow4">
               <path
-                  style="stroke-width: 40.1798"
-                  :d="dArrowFour"
-                  id="shaft4"
-                  ref="groupRefArrowFour"
-                  :fill="colorArrowFour"
-                  :transform="transformArrowFour"
+                style="stroke-width: 40.1798"
+                :d="dArrowFour"
+                id="shaft4"
+                ref="groupRefArrowFour"
+                :fill="colorArrowFour"
+                :transform="transformArrowFour"
               />
               <path
-                  style="
+                style="
                   fill: none;
                   stroke: #000000;
                   stroke-width: 1.75413;
                   stroke-dasharray: none;
                   stroke-opacity: 1;
                 "
-                  id="tip4"
-                  d="m 1178.1774,846.90543 -18.6954,-22.33904 -0.017,44.62008 z"
+                id="tip4"
+                d="m 1178.1774,846.90543 -18.6954,-22.33904 -0.017,44.62008 z"
               />
             </g>
           </g>
           <g id="zaehlwerte">
             <text
-                xml:space="preserve"
-                id="sumArrowsOneToFourLeft"
-                :style="`
+              xml:space="preserve"
+              id="sumArrowsOneToFourLeft"
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: bold;
@@ -207,21 +207,21 @@
                 fill-opacity: 1;
                 stroke-width: 43.9644;
               `"
-                x="215.22824"
-                y="707.44586"
+              x="215.22824"
+              y="707.44586"
             >
               <tspan
-                  id="tspan32"
-                  x="215.22824"
-                  y="707.44586"
+                id="tspan32"
+                x="215.22824"
+                y="707.44586"
               >
                 {{ sumArrowsOneToFour }}
               </tspan>
             </text>
             <text
-                xml:space="preserve"
-                id="sumArrowsOneToFourRight"
-                :style="`
+              xml:space="preserve"
+              id="sumArrowsOneToFourRight"
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: bold;
@@ -241,13 +241,13 @@
                 fill-opacity: 1;
                 stroke-width: 43.9644;
               `"
-                x="1288.9579"
-                y="708.37695"
+              x="1274.7208"
+              y="708.8515"
             >
               <tspan
-                  id="tspan33"
-                  x="1288.9579"
-                  y="708.37695"
+                id="tspan33"
+                x="1274.7208"
+                y="708.8515"
               >
                 {{ sumArrowsOneToFour }}
               </tspan>
@@ -314,7 +314,7 @@
                 y="615.81903"
               >
                 <tspan
-                  id="tspan35"
+                  id="tspan13"
                   x="215.83165"
                   y="615.81903"
                 >
@@ -322,14 +322,19 @@
                 </tspan>
               </text>
               <path
-                  style="fill: #000000; fill-opacity: 1; stroke-width: 29.8746"
-                  d="m 116.95317,618.45522 h 97.99999 v 1.0263 h -97.99999 z"
-                  id="separatorOneTwo"
+                style="
+                  fill: #000000;
+                  fill-opacity: 1;
+                  stroke-width: 3.26332;
+                  stroke-dasharray: none;
+                "
+                d="m 133.56306,621.30263 h 80.44096 v 1.0263 h -80.44096 z"
+                id="separatorOneTwo"
               />
               <text
-                  xml:space="preserve"
-                  id="sumArrowsOneTwo"
-                  :style="`
+                xml:space="preserve"
+                id="sumArrowsOneTwo"
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
@@ -349,13 +354,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9644;
                 `"
-                  x="215.26794"
-                  y="642.70013"
+                x="215.26794"
+                y="642.70013"
               >
                 <tspan
-                    id="tspan34"
-                    x="215.26794"
-                    y="642.70013"
+                  id="tspan34"
+                  x="215.26794"
+                  y="642.70013"
                 >
                   {{ sumArrowsOneTwo }}
                 </tspan>
@@ -363,9 +368,9 @@
             </g>
             <g id="zaehlwerteArrowsThreeFour">
               <text
-                  xml:space="preserve"
-                  id="zaehlwertArrowThree"
-                  :style="`
+                xml:space="preserve"
+                id="zaehlwertArrowThree"
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
@@ -385,21 +390,21 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                  x="1288.7062"
-                  y="799.76965"
+                x="1274.4691"
+                y="799.2951"
               >
                 <tspan
-                    id="tspan39"
-                    x="1288.7062"
-                    y="799.76965"
+                  id="tspan39"
+                  x="1274.4691"
+                  y="799.2951"
                 >
                   {{ zaehlwertArrowThree }}
                 </tspan>
               </text>
               <text
-                  xml:space="preserve"
-                  id="zaehlwertArrowFour"
-                  :style="`
+                xml:space="preserve"
+                id="zaehlwertArrowFour"
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
@@ -419,26 +424,26 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                  x="1288.0775"
-                  y="855.68152"
+                x="1273.3658"
+                y="855.68152"
               >
                 <tspan
-                    id="tspan38"
-                    x="1288.0775"
-                    y="855.68152"
+                  id="tspan14"
+                  x="1273.3658"
+                  y="855.68152"
                 >
                   {{ zaehlwertArrowFour }}
                 </tspan>
               </text>
               <path
-                  style="fill: #000000; fill-opacity: 1; stroke-width: 29.8746"
-                  d="m 1198.9417,860.12963 h 98 v 2.45 h -98 z"
-                  id="separatorThreeFour"
+                style="fill: #000000; fill-opacity: 1; stroke-width: 13.4005"
+                d="m 1186.6029,862.50248 h 87.5595 v 0.55173 h -87.5595 z"
+                id="separatorThreeFour"
               />
               <text
-                  xml:space="preserve"
-                  id="sumArrowsThreeFour"
-                  :style="`
+                xml:space="preserve"
+                id="sumArrowsThreeFour"
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
@@ -458,13 +463,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9644;
                 `"
-                  x="1288.6099"
-                  y="884.09052"
+                x="1274.8474"
+                y="884.09052"
               >
                 <tspan
-                    id="tspan37"
-                    x="1288.6099"
-                    y="884.09052"
+                  id="tspan37"
+                  x="1274.8474"
+                  y="884.09052"
                 >
                   {{ sumArrowsThreeFour }}
                 </tspan>
@@ -473,27 +478,11 @@
           </g>
         </g>
         <g id="legend">
-          <g
-              id="legend-compass"
-          >
-            <path
-                :style="`
-                fill: none;
-                fill-opacity: 1;
-                stroke: ${BelastungsplanConstants.legendColor};
-                stroke-width: 2.05093;
-                stroke-linecap: butt;
-                stroke-miterlimit: 2.5;
-                stroke-dasharray: none;
-                stroke-opacity: 1;
-              `"
-                id="compass2"
-                d="m 107.4337,29.986817 13.91905,63.782102 H 106.06633 93.514636 Z"
-            />
+          <g id="legend-compass">
             <text
-                xml:space="preserve"
-                id="compass1"
-                :style="`
+              xml:space="preserve"
+              id="compass1"
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
@@ -511,11 +500,11 @@
                 fill: ${BelastungsplanConstants.legendColor};
                 stroke-width: 2.2868;
               `"
-                x="100.269417"
-                y="84.061363"
+              x="100.26942"
+              y="84.035934"
             >
               <tspan
-                  :style="`
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
@@ -526,24 +515,38 @@
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
+                  fill: ${BelastungsplanConstants.legendColor};
+                  fill-opacity: 1;
                   stroke-width: 2.2868;
                 `"
-                  id="tspan6"
+                id="tspan6"
               >
                 N
               </tspan>
             </text>
+            <path
+              style="
+                fill: none;
+                fill-opacity: 1;
+                stroke: #666666;
+                stroke-width: 1.73910624;
+                stroke-linecap: butt;
+                stroke-miterlimit: 2.5;
+                stroke-dasharray: none;
+                stroke-opacity: 1;
+              "
+              id="compass2"
+              d="m 107.4337,29.986817 13.91905,63.782102 H 106.06633 93.514636 Z"
+            />
           </g>
-          <g
-              id="legend-zaehlstelle"
-          >
+          <g id="legend-zaehlstelle">
             <g
-                id="zaehlstelle1"
-                style="stroke-width: 28.2205; stroke-dasharray: none"
+              id="zaehlstelle1"
+              style="stroke-width: 28.2205; stroke-dasharray: none"
             >
               <text
-                  xml:space="preserve"
-                  :style="`
+                xml:space="preserve"
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
@@ -565,18 +568,18 @@
                   stroke-width: 28.2205;
                   stroke-dasharray: none;
                 `"
-                  id="zaehlstelle1-multirow"
-                  x="1107.24969"
-                  y="60.33734"
+                id="zaehlstelle1-multirow"
+                x="1107.2496"
+                y="60.337341"
               >
                 <tspan
-                    x="1107.24969"
-                    y="60.33734"
-                    id="tspan12"
+                  x="1107.2496"
+                  y="60.337341"
+                  id="tspan16"
                 >
                   <tspan
-                      style="font-weight: bold"
-                      id="tspan11"
+                    style="font-weight: bold"
+                    id="tspan15"
                   >
                     Zählstelle
                     {{ zaehlstelleStore.getZaehlstelleHeader.nummer }}
@@ -585,13 +588,13 @@
               </text>
             </g>
             <g
-                id="zaehlstelle2"
-                style="stroke-width: 28.2205; stroke-dasharray: none"
+              id="zaehlstelle2"
+              style="stroke-width: 28.2205; stroke-dasharray: none"
             >
               <text
-                  v-if="zaehlstelleStore.getZaehlstelleHeader.stadtbezirkNummer"
-                  xml:space="preserve"
-                  :style="`
+                v-if="zaehlstelleStore.getZaehlstelleHeader.stadtbezirkNummer"
+                xml:space="preserve"
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
@@ -613,27 +616,27 @@
                   stroke-width: 28.2205;
                   stroke-dasharray: none;
                 `"
-                  id="zaehlstelle2-multirow"
-                  x="1107.24969"
-                  y="86.33734"
+                id="zaehlstelle2-multirow"
+                x="1107.2496"
+                y="85.837341"
               >
                 <tspan
-                    x="1107.24969"
-                    y="86.33734"
-                    id="tspan9"
+                  x="1107.2496"
+                  y="85.837341"
+                  id="tspan17"
                 >
                   Stadtbezirk
                   {{ zaehlstelleStore.getZaehlstelleHeader.stadtbezirkNummer }}
                 </tspan>
                 <tspan
-                    x="1107.24969"
-                    y="112.26057"
-                    id="tspan10"
+                  x="1107.2496"
+                  y="112.26053"
+                  id="tspan18"
                 >
                   Zähldatum:
                   {{
                     dateUtils.getShortVersionOfDate(
-                        new Date(activeZaehlung.datum)
+                      new Date(activeZaehlung.datum)
                     )
                   }}
                 </tspan>
@@ -645,12 +648,12 @@
             style="stroke-width: 28.2205; stroke-dasharray: none"
           >
             <g
-                id="zaehlzeit1"
-                style="stroke-width: 28.2205; stroke-dasharray: none"
+              id="zaehlzeit1"
+              style="stroke-width: 28.2205; stroke-dasharray: none"
             >
               <text
-                  xml:space="preserve"
-                  :style="`
+                xml:space="preserve"
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
@@ -672,18 +675,18 @@
                   stroke-width: 28.2205;
                   stroke-dasharray: none;
                 `"
-                  id="zaehlzeit1-multirow"
-                  x="56.24969"
-                  y="1231.3373"
+                id="zaehlzeit1-multirow"
+                x="56.249691"
+                y="1231.3373"
               >
                 <tspan
-                    x="56.24969"
-                    y="1231.3373"
-                    id="tspan5"
+                  x="56.249691"
+                  y="1231.3373"
+                  id="tspan23"
                 >
                   <tspan
-                      style="font-weight: bold"
-                      id="tspan4"
+                    style="font-weight: bold"
+                    id="tspan22"
                   >
                     {{ optionen.zeitauswahl }}
                   </tspan>
@@ -719,21 +722,21 @@
                   stroke-dasharray: none;
                 `"
                 id="zaehlzeit2-multirow"
-                x="56.24969"
+                x="56.249691"
                 y="1257"
               >
                 <tspan
-                  x="56.24969"
+                  x="56.249691"
                   y="1257"
-                  id="tspan3"
+                  id="tspan24"
                 >
                   {{ zaehlzeit2 }}
                 </tspan>
               </text>
             </g>
             <text
-                xml:space="preserve"
-                :style="`
+              xml:space="preserve"
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
@@ -755,50 +758,50 @@
                 stroke-width: 28.2205;
                 stroke-dasharray: none;
               `"
-                id="verkehrsart"
-                x="56.24969"
-                y="1310.3373"
+              id="verkehrsart"
+              x="56.249691"
+              y="1310.3373"
             >
               <tspan
-                  x="56.24969"
-                  y="1310.3373"
-                  id="tspan2"
+                x="56.249691"
+                y="1310.3373"
+                id="tspan26"
               >
                 <tspan
-                    style="font-weight: bold"
-                    id="tspan1"
+                  style="font-weight: bold"
+                  id="tspan25"
                 >
                   {{ optionen.radverkehr ? "RAD" : "FUSS" }}
                 </tspan>
               </tspan>
             </text>
           </g>
-          <g
-            id="legend-massstab"
-          >
+          <g id="legend-massstab">
             <path
-                :style="`
+              :style="`
                 fill: none;
                 stroke: ${BelastungsplanConstants.legendColor};
-                stroke-width: 2.000000;
+                stroke-width: 1.51785;
                 stroke-linecap: square;
                 stroke-miterlimit: 2.5;
                 stroke-dasharray: none;
+                stroke-opacity: 1;
               `"
-                d="m 1316.5243,1294.7302 -124.9982,-0.2134 124.9982,-19.8383 z"
-                id="massstab-path1"
+              d="m 1316.5243,1294.7302 -124.9982,-0.2134 124.9982,-19.8383 z"
+              id="massstab-path1"
             />
             <path
-                style="
+              :style="`
                 fill: #000000;
-                stroke: #000000;
-                stroke-width: 1.580777;
+                stroke: ${BelastungsplanConstants.legendColor};
+                stroke-width: 1.50489;
                 stroke-linecap: square;
                 stroke-miterlimit: 2.5;
                 stroke-dasharray: none;
-              "
-                d="m 1252.7468,1284.8273 c 0.1805,8.9058 0.185,8.7945 0.185,8.7945 v 0"
-                id="massstab-path2"
+                stroke-opacity: 1;
+              `"
+              d="m 1252.7468,1284.8273 c 0.1805,8.9058 0.185,8.7945 0.185,8.7945 v 0"
+              id="massstab-path2"
             />
             <g
               id="massstab-size1"
@@ -825,6 +828,7 @@
                   inline-size: 268.729;
                   display: inline;
                   fill: #000000;
+                  fill-opacity: 1;
                   stroke-width: 28.2205;
                   stroke-dasharray: none;
                 `"
@@ -835,19 +839,19 @@
                 <tspan
                   x="1250.2496"
                   y="1315.3373"
-                  id="tspan7"
+                  id="tspan27"
                 >
                   {{ highestZaehlwertRounded / 2 }}
                 </tspan>
               </text>
             </g>
             <g
-                id="massstab-size2"
-                style="stroke-width: 28.2205; stroke-dasharray: none"
+              id="massstab-size2"
+              style="stroke-width: 28.2205; stroke-dasharray: none"
             >
               <text
-                  xml:space="preserve"
-                  :style="`
+                xml:space="preserve"
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
@@ -866,17 +870,18 @@
                   inline-size: 268.729;
                   display: inline;
                   fill: #000000;
+                  fill-opacity: 1;
                   stroke-width: 28.2205;
                   stroke-dasharray: none;
                 `"
-                  id="massstab-size2-multirow"
-                  x="1316.2496"
-                  y="1315.3373"
+                id="massstab-size2-multirow"
+                x="1316.2496"
+                y="1315.3373"
               >
                 <tspan
-                    x="1316.2496"
-                    y="1315.3373"
-                    id="tspan8"
+                  x="1316.2496"
+                  y="1315.3373"
+                  id="tspan28"
                 >
                   {{ highestZaehlwertRounded }}
                 </tspan>
@@ -988,7 +993,7 @@ const transformArrowFour = computed(() =>
 );
 
 // --- Pfad-Daten
-const dArrowOne = "m 245,567 v -28 h 910.7202 v 27.998 z";
+const dArrowOne = "m 245,567 v -28 h 909.4546 v 27.998 z";
 const dArrowTwo = "m 245.31124,623 v -28 h 909.68866 v 27.997 z";
 const dArrowThree = "m 245,804.99999 v -28 h 910.1007 v 27.997 z";
 const dArrowFour = "m 244.89933,860.99999 v -28 H 1155 v 27.997 z";

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
@@ -501,7 +501,7 @@
                 stroke-width: 2.2868;
               `"
               x="100.26942"
-              y="83.035934"
+              y="84.035934"
             >
               <tspan
                 :style="`
@@ -529,14 +529,14 @@
                 fill: none;
                 fill-opacity: 1;
                 stroke: #666666;
-                stroke-width: 1.73910624;
+                stroke-width: 1.99499999;
                 stroke-linecap: butt;
                 stroke-miterlimit: 2.5;
                 stroke-dasharray: none;
                 stroke-opacity: 1;
               "
               id="compass2"
-              d="m 107.4337,29.986817 13.91905,63.782102 H 106.06633 93.514636 Z"
+              d="m 107.4337,29.984176 13.9217,63.312817 H 106.06607 93.511995 Z"
             />
           </g>
           <g id="legend-zaehlstelle">
@@ -549,7 +549,7 @@
                 :style="`
                   font-style: normal;
                   font-variant: normal;
-                  font-weight: normal;
+                  font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-family: ${BelastungsplanConstants.fontfamily};
@@ -577,13 +577,9 @@
                   y="60.337341"
                   id="tspan16"
                 >
-                  <tspan
-                    style="font-weight: bold"
-                    id="tspan15"
-                  >
+
                     Zählstelle
                     {{ zaehlstelleStore.getZaehlstelleHeader.nummer }}
-                  </tspan>
                 </tspan>
               </text>
             </g>
@@ -618,11 +614,11 @@
                 `"
                 id="zaehlstelle2-multirow"
                 x="1107.2496"
-                y="86.837341"
+                y="85.837341"
               >
                 <tspan
                   x="1107.2496"
-                  y="86.837341"
+                  y="85.837341"
                   id="tspan17"
                 >
                   Stadtbezirk
@@ -677,11 +673,11 @@
                 `"
                 id="zaehlzeit1-multirow"
                 x="56.249691"
-                y="1231.3373"
+                y="1230.3373"
               >
                 <tspan
                   x="56.249691"
-                  y="1231.3373"
+                  y="1230.3373"
                   id="tspan23"
                 >
                   <tspan
@@ -781,7 +777,7 @@
               :style="`
                 fill: none;
                 stroke: ${BelastungsplanConstants.legendColor};
-                stroke-width: 1.51785;
+                stroke-width: 1.99499999;
                 stroke-linecap: square;
                 stroke-miterlimit: 2.5;
                 stroke-dasharray: none;

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
@@ -98,25 +98,46 @@
             </g>
           </g>
           <g id="arrows">
-            <g id="arrow4">
+            <g id="arrow1">
               <path
-                style="stroke-width: 40.1798"
-                :d="dArrowFour"
-                id="shaft4"
-                ref="groupRefArrowFour"
-                :fill="colorArrowFour"
-                :transform="transformArrowFour"
+                  style="stroke-width: 40.1656"
+                  :d="dArrowOne"
+                  id="shaft1"
+                  ref="groupRefArrowOne"
+                  :fill="colorArrowOne"
+                  :transform="transformArrowOne"
               />
               <path
-                style="
+                  style="
                   fill: none;
                   stroke: #000000;
-                  stroke-width: 1.75413;
+                  stroke-width: 2.08902;
                   stroke-dasharray: none;
                   stroke-opacity: 1;
                 "
-                id="tip4"
-                d="m 1178.1774,846.90543 -18.6954,-22.33904 -0.017,44.62008 z"
+                  id="tip1"
+                  d="m 221.73348,553.05942 19.31149,-25.58133 0.0167,51.09625 z"
+              />
+            </g>
+            <g id="arrow2">
+              <path
+                  style="stroke-width: 40.1708"
+                  :d="dArrowTwo"
+                  id="shaft2"
+                  ref="groupRefArrowTwo"
+                  :fill="colorArrowTwo"
+                  :transform="transformArrowTwo"
+              />
+              <path
+                  style="
+                  fill: none;
+                  stroke: #000000;
+                  stroke-width: 1.75545;
+                  stroke-dasharray: none;
+                  stroke-opacity: 1;
+                "
+                  id="tip2"
+                  d="m 1178.1206,609.06771 -18.7975,-22.45207 -0.017,44.84587 z"
               />
             </g>
             <g id="arrow3">
@@ -140,159 +161,97 @@
                 d="m 221.49329,791.09394 19.39305,-22.32164 0.0169,44.58532 z"
               />
             </g>
-            <g id="arrow2">
+            <g id="arrow4">
               <path
-                style="stroke-width: 40.1708"
-                :d="dArrowTwo"
-                id="shaft2"
-                ref="groupRefArrowTwo"
-                :fill="colorArrowTwo"
-                :transform="transformArrowTwo"
+                  style="stroke-width: 40.1798"
+                  :d="dArrowFour"
+                  id="shaft4"
+                  ref="groupRefArrowFour"
+                  :fill="colorArrowFour"
+                  :transform="transformArrowFour"
               />
               <path
-                style="
+                  style="
                   fill: none;
                   stroke: #000000;
-                  stroke-width: 1.75545;
+                  stroke-width: 1.75413;
                   stroke-dasharray: none;
                   stroke-opacity: 1;
                 "
-                id="tip2"
-                d="m 1178.1206,609.06771 -18.7975,-22.45207 -0.017,44.84587 z"
-              />
-            </g>
-            <g id="arrow1">
-              <path
-                style="stroke-width: 40.1656"
-                :d="dArrowOne"
-                id="shaft1"
-                ref="groupRefArrowOne"
-                :fill="colorArrowOne"
-                :transform="transformArrowOne"
-              />
-              <path
-                style="
-                  fill: none;
-                  stroke: #000000;
-                  stroke-width: 2.08902;
-                  stroke-dasharray: none;
-                  stroke-opacity: 1;
-                "
-                id="tip1"
-                d="m 221.73348,553.05942 19.31149,-25.58133 0.0167,51.09625 z"
+                  id="tip4"
+                  d="m 1178.1774,846.90543 -18.6954,-22.33904 -0.017,44.62008 z"
               />
             </g>
           </g>
           <g id="zaehlwerte">
-            <g id="zaehlwerteArrowsThreeFour">
-              <text
+            <text
                 xml:space="preserve"
-                id="zaehlwertArrowThree"
+                id="sumArrowsOneToFourLeft"
                 :style="`
-                  font-style: normal;
-                  font-variant: normal;
-                  font-weight: normal;
-                  font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
-                  font-variant-ligatures: normal;
-                  font-variant-caps: normal;
-                  font-variant-numeric: normal;
-                  font-variant-east-asian: normal;
-                  text-align: end;
-                  writing-mode: rl-tb;
-                  direction: rtl;
-                  white-space: pre;
-                  display: inline;
-                  fill: #000000;
-                  fill-opacity: 1;
-                  stroke-width: 43.9482;
-                `"
-                x="1288.7062"
-                y="799.76965"
+                font-style: normal;
+                font-variant: normal;
+                font-weight: bold;
+                font-stretch: normal;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
+                font-variant-ligatures: normal;
+                font-variant-caps: normal;
+                font-variant-numeric: normal;
+                font-variant-east-asian: normal;
+                text-align: end;
+                writing-mode: rl-tb;
+                direction: rtl;
+                white-space: pre;
+                display: inline;
+                fill: #000000;
+                fill-opacity: 1;
+                stroke-width: 43.9644;
+              `"
+                x="215.22824"
+                y="707.44586"
+            >
+              <tspan
+                  id="tspan32"
+                  x="215.22824"
+                  y="707.44586"
               >
-                <tspan
-                  id="tspan39"
-                  x="1288.7062"
-                  y="799.76965"
-                >
-                  {{ zaehlwertArrowThree }}
-                </tspan>
-              </text>
-              <text
+                {{ sumArrowsOneToFour }}
+              </tspan>
+            </text>
+            <text
                 xml:space="preserve"
-                id="zaehlwertArrowFour"
+                id="sumArrowsOneToFourRight"
                 :style="`
-                  font-style: normal;
-                  font-variant: normal;
-                  font-weight: normal;
-                  font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
-                  font-variant-ligatures: normal;
-                  font-variant-caps: normal;
-                  font-variant-numeric: normal;
-                  font-variant-east-asian: normal;
-                  text-align: end;
-                  writing-mode: rl-tb;
-                  direction: rtl;
-                  white-space: pre;
-                  display: inline;
-                  fill: #000000;
-                  fill-opacity: 1;
-                  stroke-width: 43.9482;
-                `"
-                x="1288.0775"
-                y="855.68152"
+                font-style: normal;
+                font-variant: normal;
+                font-weight: bold;
+                font-stretch: normal;
+                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-familiy: ${BelastungsplanConstants.fontfamily};
+                font-variant-ligatures: normal;
+                font-variant-caps: normal;
+                font-variant-numeric: normal;
+                font-variant-east-asian: normal;
+                text-align: end;
+                writing-mode: rl-tb;
+                direction: rtl;
+                white-space: pre;
+                display: inline;
+                fill: #000000;
+                fill-opacity: 1;
+                stroke-width: 43.9644;
+              `"
+                x="1288.9579"
+                y="708.37695"
+            >
+              <tspan
+                  id="tspan33"
+                  x="1288.9579"
+                  y="708.37695"
               >
-                <tspan
-                  id="tspan38"
-                  x="1288.0775"
-                  y="855.68152"
-                >
-                  {{ zaehlwertArrowFour }}
-                </tspan>
-              </text>
-              <path
-                style="fill: #000000; fill-opacity: 1; stroke-width: 29.8746"
-                d="m 1198.9417,860.12963 h 98 v 2.45 h -98 z"
-                id="separatorThreeFour"
-              />
-              <text
-                xml:space="preserve"
-                id="sumArrowsThreeFour"
-                :style="`
-                  font-style: normal;
-                  font-variant: normal;
-                  font-weight: bold;
-                  font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
-                  font-variant-ligatures: normal;
-                  font-variant-caps: normal;
-                  font-variant-numeric: normal;
-                  font-variant-east-asian: normal;
-                  text-align: end;
-                  writing-mode: rl-tb;
-                  direction: rtl;
-                  white-space: pre;
-                  display: inline;
-                  fill: #000000;
-                  fill-opacity: 1;
-                  stroke-width: 43.9644;
-                `"
-                x="1288.6099"
-                y="884.09052"
-              >
-                <tspan
-                  id="tspan37"
-                  x="1288.6099"
-                  y="884.09052"
-                >
-                  {{ sumArrowsThreeFour }}
-                </tspan>
-              </text>
-            </g>
+                {{ sumArrowsOneToFour }}
+              </tspan>
+            </text>
             <g id="zaehlwerteArrowsOneTwo">
               <text
                 xml:space="preserve"
@@ -328,11 +287,6 @@
                   {{ zaehlwertArrowOne }}
                 </tspan>
               </text>
-              <path
-                style="fill: #000000; fill-opacity: 1; stroke-width: 29.8746"
-                d="m 116.95317,618.45522 h 97.99999 v 1.0263 h -97.99999 z"
-                id="separatorOneTwo"
-              />
               <text
                 xml:space="preserve"
                 id="zaehlwertArrowTwo"
@@ -367,10 +321,15 @@
                   {{ zaehlwertArrowTwo }}
                 </tspan>
               </text>
+              <path
+                  style="fill: #000000; fill-opacity: 1; stroke-width: 29.8746"
+                  d="m 116.95317,618.45522 h 97.99999 v 1.0263 h -97.99999 z"
+                  id="separatorOneTwo"
+              />
               <text
-                xml:space="preserve"
-                id="sumArrowsOneTwo"
-                :style="`
+                  xml:space="preserve"
+                  id="sumArrowsOneTwo"
+                  :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
@@ -390,102 +349,157 @@
                   fill-opacity: 1;
                   stroke-width: 43.9644;
                 `"
-                x="215.26794"
-                y="642.70013"
-              >
-                <tspan
-                  id="tspan34"
                   x="215.26794"
                   y="642.70013"
+              >
+                <tspan
+                    id="tspan34"
+                    x="215.26794"
+                    y="642.70013"
                 >
                   {{ sumArrowsOneTwo }}
                 </tspan>
               </text>
             </g>
-            <text
-              xml:space="preserve"
-              id="sumArrowsOneToFourRight"
-              :style="`
-                font-style: normal;
-                font-variant: normal;
-                font-weight: bold;
-                font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
-                font-familiy: ${BelastungsplanConstants.fontfamily};
-                font-variant-ligatures: normal;
-                font-variant-caps: normal;
-                font-variant-numeric: normal;
-                font-variant-east-asian: normal;
-                text-align: end;
-                writing-mode: rl-tb;
-                direction: rtl;
-                white-space: pre;
-                display: inline;
-                fill: #000000;
-                fill-opacity: 1;
-                stroke-width: 43.9644;
-              `"
-              x="1288.9579"
-              y="708.37695"
-            >
-              <tspan
-                id="tspan33"
-                x="1288.9579"
-                y="708.37695"
+            <g id="zaehlwerteArrowsThreeFour">
+              <text
+                  xml:space="preserve"
+                  id="zaehlwertArrowThree"
+                  :style="`
+                  font-style: normal;
+                  font-variant: normal;
+                  font-weight: normal;
+                  font-stretch: normal;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  font-variant-ligatures: normal;
+                  font-variant-caps: normal;
+                  font-variant-numeric: normal;
+                  font-variant-east-asian: normal;
+                  text-align: end;
+                  writing-mode: rl-tb;
+                  direction: rtl;
+                  white-space: pre;
+                  display: inline;
+                  fill: #000000;
+                  fill-opacity: 1;
+                  stroke-width: 43.9482;
+                `"
+                  x="1288.7062"
+                  y="799.76965"
               >
-                {{ sumArrowsOneToFour }}
-              </tspan>
-            </text>
-            <text
-              xml:space="preserve"
-              id="sumArrowsOneToFourLeft"
-              :style="`
-                font-style: normal;
-                font-variant: normal;
-                font-weight: bold;
-                font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
-                font-familiy: ${BelastungsplanConstants.fontfamily};
-                font-variant-ligatures: normal;
-                font-variant-caps: normal;
-                font-variant-numeric: normal;
-                font-variant-east-asian: normal;
-                text-align: end;
-                writing-mode: rl-tb;
-                direction: rtl;
-                white-space: pre;
-                display: inline;
-                fill: #000000;
-                fill-opacity: 1;
-                stroke-width: 43.9644;
-              `"
-              x="215.22824"
-              y="707.44586"
-            >
-              <tspan
-                id="tspan32"
-                x="215.22824"
-                y="707.44586"
+                <tspan
+                    id="tspan39"
+                    x="1288.7062"
+                    y="799.76965"
+                >
+                  {{ zaehlwertArrowThree }}
+                </tspan>
+              </text>
+              <text
+                  xml:space="preserve"
+                  id="zaehlwertArrowFour"
+                  :style="`
+                  font-style: normal;
+                  font-variant: normal;
+                  font-weight: normal;
+                  font-stretch: normal;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  font-variant-ligatures: normal;
+                  font-variant-caps: normal;
+                  font-variant-numeric: normal;
+                  font-variant-east-asian: normal;
+                  text-align: end;
+                  writing-mode: rl-tb;
+                  direction: rtl;
+                  white-space: pre;
+                  display: inline;
+                  fill: #000000;
+                  fill-opacity: 1;
+                  stroke-width: 43.9482;
+                `"
+                  x="1288.0775"
+                  y="855.68152"
               >
-                {{ sumArrowsOneToFour }}
-              </tspan>
-            </text>
+                <tspan
+                    id="tspan38"
+                    x="1288.0775"
+                    y="855.68152"
+                >
+                  {{ zaehlwertArrowFour }}
+                </tspan>
+              </text>
+              <path
+                  style="fill: #000000; fill-opacity: 1; stroke-width: 29.8746"
+                  d="m 1198.9417,860.12963 h 98 v 2.45 h -98 z"
+                  id="separatorThreeFour"
+              />
+              <text
+                  xml:space="preserve"
+                  id="sumArrowsThreeFour"
+                  :style="`
+                  font-style: normal;
+                  font-variant: normal;
+                  font-weight: bold;
+                  font-stretch: normal;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  font-variant-ligatures: normal;
+                  font-variant-caps: normal;
+                  font-variant-numeric: normal;
+                  font-variant-east-asian: normal;
+                  text-align: end;
+                  writing-mode: rl-tb;
+                  direction: rtl;
+                  white-space: pre;
+                  display: inline;
+                  fill: #000000;
+                  fill-opacity: 1;
+                  stroke-width: 43.9644;
+                `"
+                  x="1288.6099"
+                  y="884.09052"
+              >
+                <tspan
+                    id="tspan37"
+                    x="1288.6099"
+                    y="884.09052"
+                >
+                  {{ sumArrowsThreeFour }}
+                </tspan>
+              </text>
+            </g>
           </g>
         </g>
         <g id="legend">
           <g
-            id="legend-zaehlinfo"
-            style="stroke-width: 28.2205; stroke-dasharray: none"
+              id="legend-compass"
           >
+            <path
+                :style="`
+                fill: none;
+                fill-opacity: 1;
+                stroke: ${BelastungsplanConstants.legendColor};
+                stroke-width: 2.05093;
+                stroke-linecap: butt;
+                stroke-miterlimit: 2.5;
+                stroke-dasharray: none;
+                stroke-opacity: 1;
+              `"
+                id="compass2"
+                d="m 107.4337,29.986817 13.91905,63.782102 H 106.06633 93.514636 Z"
+            />
             <text
-              xml:space="preserve"
-              :style="`
+                xml:space="preserve"
+                id="compass1"
+                :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth};
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                font-family: sans-serif;
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -494,30 +508,188 @@
                 writing-mode: lr-tb;
                 direction: ltr;
                 text-anchor: start;
-                white-space: pre;
-                inline-size: 268.729;
-                display: inline;
-                fill: #000000;
-                stroke-width: 28.2205;
-                stroke-dasharray: none;
+                fill: ${BelastungsplanConstants.legendColor};
+                stroke-width: 2.2868;
               `"
-              id="verkehrsart"
-              x="56.24969"
-              y="1310.3373"
+                x="100.269417"
+                y="84.061363"
             >
               <tspan
-                x="56.24969"
-                y="1310.3373"
-                id="tspan2"
+                  :style="`
+                  font-style: normal;
+                  font-variant: normal;
+                  font-weight: normal;
+                  font-stretch: normal;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-family: ${BelastungsplanConstants.fontfamily};
+                  font-variant-ligatures: normal;
+                  font-variant-caps: normal;
+                  font-variant-numeric: normal;
+                  font-variant-east-asian: normal;
+                  stroke-width: 2.2868;
+                `"
+                  id="tspan6"
               >
-                <tspan
-                  style="font-weight: bold"
-                  id="tspan1"
-                >
-                  {{ optionen.radverkehr ? "RAD" : "FUSS" }}
-                </tspan>
+                N
               </tspan>
             </text>
+          </g>
+          <g
+              id="legend-zaehlstelle"
+          >
+            <g
+                id="zaehlstelle1"
+                style="stroke-width: 28.2205; stroke-dasharray: none"
+            >
+              <text
+                  xml:space="preserve"
+                  :style="`
+                  font-style: normal;
+                  font-variant: normal;
+                  font-weight: normal;
+                  font-stretch: normal;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  font-variant-ligatures: normal;
+                  font-variant-caps: normal;
+                  font-variant-numeric: normal;
+                  font-variant-east-asian: normal;
+                  text-align: start;
+                  writing-mode: lr-tb;
+                  direction: ltr;
+                  text-anchor: start;
+                  white-space: pre;
+                  inline-size: 268.729;
+                  display: inline;
+                  fill: #000000;
+                  stroke-width: 28.2205;
+                  stroke-dasharray: none;
+                `"
+                  id="zaehlstelle1-multirow"
+                  x="1107.24969"
+                  y="60.33734"
+              >
+                <tspan
+                    x="1107.24969"
+                    y="60.33734"
+                    id="tspan12"
+                >
+                  <tspan
+                      style="font-weight: bold"
+                      id="tspan11"
+                  >
+                    Zählstelle
+                    {{ zaehlstelleStore.getZaehlstelleHeader.nummer }}
+                  </tspan>
+                </tspan>
+              </text>
+            </g>
+            <g
+                id="zaehlstelle2"
+                style="stroke-width: 28.2205; stroke-dasharray: none"
+            >
+              <text
+                  v-if="zaehlstelleStore.getZaehlstelleHeader.stadtbezirkNummer"
+                  xml:space="preserve"
+                  :style="`
+                  font-style: normal;
+                  font-variant: normal;
+                  font-weight: normal;
+                  font-stretch: normal;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  font-variant-ligatures: normal;
+                  font-variant-caps: normal;
+                  font-variant-numeric: normal;
+                  font-variant-east-asian: normal;
+                  text-align: start;
+                  writing-mode: lr-tb;
+                  direction: ltr;
+                  text-anchor: start;
+                  white-space: pre;
+                  inline-size: 268.729;
+                  display: inline;
+                  fill: #000000;
+                  stroke-width: 28.2205;
+                  stroke-dasharray: none;
+                `"
+                  id="zaehlstelle2-multirow"
+                  x="1107.24969"
+                  y="86.33734"
+              >
+                <tspan
+                    x="1107.24969"
+                    y="86.33734"
+                    id="tspan9"
+                >
+                  Stadtbezirk
+                  {{ zaehlstelleStore.getZaehlstelleHeader.stadtbezirkNummer }}
+                </tspan>
+                <tspan
+                    x="1107.24969"
+                    y="112.26057"
+                    id="tspan10"
+                >
+                  Zähldatum:
+                  {{
+                    dateUtils.getShortVersionOfDate(
+                        new Date(activeZaehlung.datum)
+                    )
+                  }}
+                </tspan>
+              </text>
+            </g>
+          </g>
+          <g
+            id="legend-zaehlinfo"
+            style="stroke-width: 28.2205; stroke-dasharray: none"
+          >
+            <g
+                id="zaehlzeit1"
+                style="stroke-width: 28.2205; stroke-dasharray: none"
+            >
+              <text
+                  xml:space="preserve"
+                  :style="`
+                  font-style: normal;
+                  font-variant: normal;
+                  font-weight: normal;
+                  font-stretch: normal;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  font-variant-ligatures: normal;
+                  font-variant-caps: normal;
+                  font-variant-numeric: normal;
+                  font-variant-east-asian: normal;
+                  text-align: start;
+                  writing-mode: lr-tb;
+                  direction: ltr;
+                  text-anchor: start;
+                  white-space: pre;
+                  inline-size: 268.729;
+                  display: inline;
+                  fill: #000000;
+                  stroke-width: 28.2205;
+                  stroke-dasharray: none;
+                `"
+                  id="zaehlzeit1-multirow"
+                  x="56.24969"
+                  y="1231.3373"
+              >
+                <tspan
+                    x="56.24969"
+                    y="1231.3373"
+                    id="tspan5"
+                >
+                  <tspan
+                      style="font-weight: bold"
+                      id="tspan4"
+                  >
+                    {{ optionen.zeitauswahl }}
+                  </tspan>
+                </tspan>
+              </text>
+            </g>
             <g
               id="zaehlzeit2"
               style="stroke-width: 28.2205; stroke-dasharray: none"
@@ -559,80 +731,15 @@
                 </tspan>
               </text>
             </g>
-            <g
-              id="zaehlzeit1"
-              style="stroke-width: 28.2205; stroke-dasharray: none"
-            >
-              <text
+            <text
                 xml:space="preserve"
                 :style="`
-                  font-style: normal;
-                  font-variant: normal;
-                  font-weight: normal;
-                  font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
-                  font-variant-ligatures: normal;
-                  font-variant-caps: normal;
-                  font-variant-numeric: normal;
-                  font-variant-east-asian: normal;
-                  text-align: start;
-                  writing-mode: lr-tb;
-                  direction: ltr;
-                  text-anchor: start;
-                  white-space: pre;
-                  inline-size: 268.729;
-                  display: inline;
-                  fill: #000000;
-                  stroke-width: 28.2205;
-                  stroke-dasharray: none;
-                `"
-                id="zaehlzeit1-multirow"
-                x="56.24969"
-                y="1231.3373"
-              >
-                <tspan
-                  x="56.24969"
-                  y="1231.3373"
-                  id="tspan5"
-                >
-                  <tspan
-                    style="font-weight: bold"
-                    id="tspan4"
-                  >
-                    {{ optionen.zeitauswahl }}
-                  </tspan>
-                </tspan>
-              </text>
-            </g>
-          </g>
-          <g
-            id="legend-compass"
-          >
-            <path
-              :style="`
-                fill: none;
-                fill-opacity: 1;
-                stroke: ${BelastungsplanConstants.legendColor};
-                stroke-width: 2.05093;
-                stroke-linecap: butt;
-                stroke-miterlimit: 2.5;
-                stroke-dasharray: none;
-                stroke-opacity: 1;
-              `"
-              id="compass2"
-              d="m 107.4337,29.986817 13.91905,63.782102 H 106.06633 93.514636 Z"
-            />
-            <text
-              xml:space="preserve"
-              id="compass1"
-              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth};
-                font-family: sans-serif;
+                font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -641,35 +748,58 @@
                 writing-mode: lr-tb;
                 direction: ltr;
                 text-anchor: start;
-                fill: ${BelastungsplanConstants.legendColor};
-                stroke-width: 2.2868;
+                white-space: pre;
+                inline-size: 268.729;
+                display: inline;
+                fill: #000000;
+                stroke-width: 28.2205;
+                stroke-dasharray: none;
               `"
-              x="100.269417"
-              y="84.061363"
+                id="verkehrsart"
+                x="56.24969"
+                y="1310.3373"
             >
               <tspan
-                :style="`
-                  font-style: normal;
-                  font-variant: normal;
-                  font-weight: normal;
-                  font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
-                  font-family: ${BelastungsplanConstants.fontfamily};
-                  font-variant-ligatures: normal;
-                  font-variant-caps: normal;
-                  font-variant-numeric: normal;
-                  font-variant-east-asian: normal;
-                  stroke-width: 2.2868;
-                `"
-                id="tspan6"
+                  x="56.24969"
+                  y="1310.3373"
+                  id="tspan2"
               >
-                N
+                <tspan
+                    style="font-weight: bold"
+                    id="tspan1"
+                >
+                  {{ optionen.radverkehr ? "RAD" : "FUSS" }}
+                </tspan>
               </tspan>
             </text>
           </g>
           <g
             id="legend-massstab"
           >
+            <path
+                :style="`
+                fill: none;
+                stroke: ${BelastungsplanConstants.legendColor};
+                stroke-width: 2.000000;
+                stroke-linecap: square;
+                stroke-miterlimit: 2.5;
+                stroke-dasharray: none;
+              `"
+                d="m 1316.5243,1294.7302 -124.9982,-0.2134 124.9982,-19.8383 z"
+                id="massstab-path1"
+            />
+            <path
+                style="
+                fill: #000000;
+                stroke: #000000;
+                stroke-width: 1.580777;
+                stroke-linecap: square;
+                stroke-miterlimit: 2.5;
+                stroke-dasharray: none;
+              "
+                d="m 1252.7468,1284.8273 c 0.1805,8.9058 0.185,8.7945 0.185,8.7945 v 0"
+                id="massstab-path2"
+            />
             <g
               id="massstab-size1"
               style="stroke-width: 28.2205; stroke-dasharray: none"
@@ -712,12 +842,12 @@
               </text>
             </g>
             <g
-              id="massstab-size2"
-              style="stroke-width: 28.2205; stroke-dasharray: none"
+                id="massstab-size2"
+                style="stroke-width: 28.2205; stroke-dasharray: none"
             >
               <text
-                xml:space="preserve"
-                :style="`
+                  xml:space="preserve"
+                  :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
@@ -739,146 +869,16 @@
                   stroke-width: 28.2205;
                   stroke-dasharray: none;
                 `"
-                id="massstab-size2-multirow"
-                x="1316.2496"
-                y="1315.3373"
+                  id="massstab-size2-multirow"
+                  x="1316.2496"
+                  y="1315.3373"
               >
                 <tspan
                     x="1316.2496"
                     y="1315.3373"
-                  id="tspan8"
+                    id="tspan8"
                 >
                   {{ highestZaehlwertRounded }}
-                </tspan>
-              </text>
-            </g>
-            <path
-              style="
-                fill: #000000;
-                stroke: #000000;
-                stroke-width: 1.580777;
-                stroke-linecap: square;
-                stroke-miterlimit: 2.5;
-                stroke-dasharray: none;
-              "
-              d="m 1252.7468,1284.8273 c 0.1805,8.9058 0.185,8.7945 0.185,8.7945 v 0"
-              id="massstab-path2"
-            />
-            <path
-              :style="`
-                fill: none;
-                stroke: ${BelastungsplanConstants.legendColor};
-                stroke-width: 2.000000;
-                stroke-linecap: square;
-                stroke-miterlimit: 2.5;
-                stroke-dasharray: none;
-              `"
-              d="m 1316.5243,1294.7302 -124.9982,-0.2134 124.9982,-19.8383 z"
-              id="massstab-path1"
-            />
-          </g>
-          <g
-            id="legend-zaehlstelle"
-          >
-            <g
-              id="zaehlstelle2"
-              style="stroke-width: 28.2205; stroke-dasharray: none"
-            >
-              <text
-                v-if="zaehlstelleStore.getZaehlstelleHeader.stadtbezirkNummer"
-                xml:space="preserve"
-                :style="`
-                  font-style: normal;
-                  font-variant: normal;
-                  font-weight: normal;
-                  font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
-                  font-variant-ligatures: normal;
-                  font-variant-caps: normal;
-                  font-variant-numeric: normal;
-                  font-variant-east-asian: normal;
-                  text-align: start;
-                  writing-mode: lr-tb;
-                  direction: ltr;
-                  text-anchor: start;
-                  white-space: pre;
-                  inline-size: 268.729;
-                  display: inline;
-                  fill: #000000;
-                  stroke-width: 28.2205;
-                  stroke-dasharray: none;
-                `"
-                id="zaehlstelle2-multirow"
-                x="1107.24969"
-                y="86.33734"
-              >
-                <tspan
-                  x="1107.24969"
-                  y="86.33734"
-                  id="tspan9"
-                >
-                  Stadtbezirk
-                  {{ zaehlstelleStore.getZaehlstelleHeader.stadtbezirkNummer }}
-                </tspan>
-                <tspan
-                  x="1107.24969"
-                  y="112.26057"
-                  id="tspan10"
-                >
-                  Zähldatum:
-                  {{
-                    dateUtils.getShortVersionOfDate(
-                      new Date(activeZaehlung.datum)
-                    )
-                  }}
-                </tspan>
-              </text>
-            </g>
-            <g
-              id="zaehlstelle1"
-              style="stroke-width: 28.2205; stroke-dasharray: none"
-            >
-              <text
-                xml:space="preserve"
-                :style="`
-                  font-style: normal;
-                  font-variant: normal;
-                  font-weight: normal;
-                  font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
-                  font-variant-ligatures: normal;
-                  font-variant-caps: normal;
-                  font-variant-numeric: normal;
-                  font-variant-east-asian: normal;
-                  text-align: start;
-                  writing-mode: lr-tb;
-                  direction: ltr;
-                  text-anchor: start;
-                  white-space: pre;
-                  inline-size: 268.729;
-                  display: inline;
-                  fill: #000000;
-                  stroke-width: 28.2205;
-                  stroke-dasharray: none;
-                `"
-                id="zaehlstelle1-multirow"
-                x="1107.24969"
-                y="60.33734"
-              >
-                <tspan
-                  x="1107.24969"
-                  y="60.33734"
-                  id="tspan12"
-                >
-                  <tspan
-                    style="font-weight: bold"
-                    id="tspan11"
-                  >
-                    Zählstelle
-                    {{ zaehlstelleStore.getZaehlstelleHeader.nummer }}
-                  </tspan>
                 </tspan>
               </text>
             </g>

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
@@ -30,8 +30,8 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 33.4058px;
-                  font-family: sans-serif-serif;
+                  font-size: 24.6944px;
+                  font-family: Roboto, Arial, Helvetica, sans-serif;
                   -inkscape-font-specification: &quot;sans-serif, Normal&quot;;
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -44,15 +44,14 @@
                   fill: #000000;
                   stroke-width: 39.1848;
                 "
-                x="699.24969"
-                y="709.21594"
+                x="697.23627"
+                y="704.51794"
                 id="singlerow"
               >
                 <tspan
-                  id="tspan15"
-                  style="stroke-width: 39.1848"
-                  x="699.24969"
-                  y="709.21594"
+                  id="tspan21"
+                  x="697.23627"
+                  y="704.51794"
                 >
                   {{ firstStreetname[0] }}
                 </tspan>
@@ -65,8 +64,8 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 33.4058px;
-                  font-family: sans-serif-serif;
+                  font-size: 24.6944px;
+                  font-family: Roboto, Arial, Helvetica, sans-serif;
                   -inkscape-font-specification: &quot;sans-serif, Normal&quot;;
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -84,18 +83,16 @@
                 y="688.33734"
               >
                 <tspan
-                  id="tspan20"
-                  style="stroke-width: 39.1848"
+                  id="tspan19"
                   x="699.24969"
                   y="688.33734"
                 >
                   {{ firstStreetname[0] }}
                 </tspan>
                 <tspan
-                  id="tspan1"
-                  style="stroke-width: 39.1848"
+                  id="tspan20"
                   x="699.24969"
-                  y="730.0946"
+                  y="719.49121"
                 >
                   {{ firstStreetname[1] }}
                 </tspan>
@@ -104,101 +101,116 @@
           </g>
           <g id="arrows">
             <g
-              id="arrow4"
-              ref="groupRefArrowFour"
-              :transform="transformArrowFour"
+                id="arrow4"
+                ref="groupRefArrowFour"
             >
               <path
-                style="stroke-width: 40.9429"
+                style="stroke-width: 40.1798"
                 :d="dArrowFour"
-                id="path4"
+                id="shaft4"
                 :fill="colorArrowFour"
+                :transform="transformArrowFour"
               />
               <path
-                style="stroke-width: 78.3672"
-                id="spike4"
-                d="m 15265.992,17469.828 -304.316,176.002 -0.265,-351.547 z"
-                :fill="colorArrowFour"
-                transform="matrix(0.09192953,0,0,0.07964786,-213.39551,-544.45264)"
+                style="
+                  fill: none;
+                  stroke: #000000;
+                  stroke-width: 1.75413;
+                  stroke-dasharray: none;
+                  stroke-opacity: 1;
+                "
+                id="tip4"
+                d="m 1178.1774,846.90543 -18.6954,-22.33904 -0.017,44.62008 z"
               />
             </g>
             <g
-              id="arrow3"
-              ref="groupRefArrowThree"
-              :transform="transformArrowThree"
+                id="arrow3"
+                ref="groupRefArrowThree"
             >
               <path
-                style="stroke-width: 40.9429"
+                style="stroke-width: 40.1798"
                 :d="dArrowThree"
-                id="path3"
+                id="shaft3"
                 :fill="colorArrowThree"
+                :transform="transformArrowThree"
               />
               <path
-                style="stroke-width: 78.3672"
-                id="spike3"
-                d="m 15265.992,17469.828 -304.316,176.002 -0.265,-351.547 z"
-                :fill="colorArrowThree"
-                transform="matrix(-0.09192953,0,0,-0.07964786,1613.3955,2182.4526)"
+                style="
+                  fill: none;
+                  stroke: #000000;
+                  stroke-width: 1.7698;
+                  stroke-dasharray: none;
+                  stroke-opacity: 1;
+                "
+                id="tip3"
+                d="m 221.49329,791.09394 19.39305,-22.32164 0.0169,44.58532 z"
               />
             </g>
             <g
-              id="arrow2"
-              ref="groupRefArrowTwo"
-              :transform="transformArrowTwo"
+                id="arrow2"
+                ref="groupRefArrowTwo"
             >
               <path
-                style="stroke-width: 40.943"
+                style="stroke-width: 40.1708"
                 :d="dArrowTwo"
-                id="path2"
+                id="shaft2"
                 :fill="colorArrowTwo"
+                :transform="transformArrowTwo"
               />
               <path
-                style="stroke-width: 78.3672"
-                id="spike2"
-                d="m 15265.992,17469.828 -304.316,176.002 -0.265,-351.547 z"
-                :fill="colorArrowTwo"
-                transform="matrix(0.09192953,0,0,0.07964786,-213.39551,-782.45264)"
+                style="
+                  fill: none;
+                  stroke: #000000;
+                  stroke-width: 1.75545;
+                  stroke-dasharray: none;
+                  stroke-opacity: 1;
+                "
+                id="tip2"
+                d="m 1178.1206,609.06771 -18.7975,-22.45207 -0.017,44.84587 z"
               />
             </g>
             <g
-              id="arrow1"
-              ref="groupRefArrowOne"
-              :transform="transformArrowOne"
+                id="arrow1"
+                ref="groupRefArrowOne"
             >
               <path
-                style="stroke-width: 40.9431"
+                style="stroke-width: 40.1656"
                 :d="dArrowOne"
-                id="path1"
+                id="shaft1"
                 :fill="colorArrowOne"
+                :transform="transformArrowOne"
               />
               <path
-                style="stroke-width: 78.3672"
-                id="spike1"
-                d="m 15265.992,17469.828 -304.316,176.002 -0.265,-351.547 z"
-                :fill="colorArrowOne"
-                transform="matrix(-0.09192953,0,0,-0.07964786,1613.3955,1944.4526)"
+                style="
+                  fill: none;
+                  stroke: #000000;
+                  stroke-width: 2.08902;
+                  stroke-dasharray: none;
+                  stroke-opacity: 1;
+                "
+                id="tip1"
+                d="m 221.73348,553.05942 19.31149,-25.58133 0.0167,51.09625 z"
               />
             </g>
           </g>
-          <g id="layer1">
-            <g id="layer2">
+          <g id="zaehlwerte">
+            <g id="zaehlwerteArrowsThreeFour">
               <text
                 xml:space="preserve"
-                transform="scale(0.86707182,1.153307)"
-                id="text3"
+                id="zaehlwertArrowThree"
                 style="
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: sans-serif-serif;
+                  font-size: 24.6944px;
+                  font-family:Roboto, Arial, Helvetica, sans-serif;
                   -inkscape-font-specification: &quot;Arial, Normal&quot;;
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
-                  text-align: start;
+                  text-align: end;
                   writing-mode: rl-tb;
                   direction: rtl;
                   white-space: pre;
@@ -207,48 +219,33 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 "
-                x="376.95462"
-                y="-93.991508"
+                x="1298.7062"
+                y="799.76965"
               >
                 <tspan
-                  x="1533.9819"
-                  y="693.90204"
-                  id="tspan3"
-                  style="
-                    font-style: normal;
-                    font-variant: normal;
-                    font-weight: normal;
-                    font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: sans-serif-serif;
-                    -inkscape-font-specification: &quot;Arial, Normal&quot;;
-                    font-variant-ligatures: normal;
-                    font-variant-caps: normal;
-                    font-variant-numeric: normal;
-                    font-variant-east-asian: normal;
-                    stroke-width: 43.9482;
-                  "
+                  id="tspan39"
+                  x="1298.7062"
+                  y="799.76965"
                 >
                   {{ zaehlwertArrowThree }}
                 </tspan>
               </text>
               <text
                 xml:space="preserve"
-                transform="scale(0.86707182,1.153307)"
-                id="text4"
+                id="zaehlwertArrowFour"
                 style="
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: sans-serif-serif;
+                  font-size: 24.6944px;
+                  font-family:Roboto, Arial, Helvetica, sans-serif;
                   -inkscape-font-specification: &quot;Arial, Normal&quot;;
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
-                  text-align: start;
+                  text-align: end;
                   writing-mode: rl-tb;
                   direction: rtl;
                   white-space: pre;
@@ -257,53 +254,38 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 "
-                x="376.95462"
-                y="-45.435368"
+                x="1298.0775"
+                y="855.68152"
               >
                 <tspan
-                  x="1533.9819"
-                  y="742.45807"
-                  id="tspan4"
-                  style="
-                    font-style: normal;
-                    font-variant: normal;
-                    font-weight: normal;
-                    font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: sans-serif-serif;
-                    -inkscape-font-specification: &quot;Arial, Normal&quot;;
-                    font-variant-ligatures: normal;
-                    font-variant-caps: normal;
-                    font-variant-numeric: normal;
-                    font-variant-east-asian: normal;
-                    stroke-width: 43.9482;
-                  "
+                  id="tspan38"
+                  x="1298.0775"
+                  y="855.68152"
                 >
                   {{ zaehlwertArrowFour }}
                 </tspan>
               </text>
               <path
                 style="fill: #000000; fill-opacity: 1; stroke-width: 29.8746"
-                d="m 1231.93,859.24999 h 98 v 2.45 h -98 z"
-                id="path5-1"
+                d="m 1198.9417,860.12963 h 98 v 2.45 h -98 z"
+                id="separatorThreeFour"
               />
               <text
                 xml:space="preserve"
-                transform="scale(0.86675167,1.153733)"
-                id="text5"
+                id="sumArrowsThreeFour"
                 style="
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: sans-serif-serif;
+                  font-size: 24.6944px;
+                  font-family:Roboto, Arial, Helvetica, sans-serif;
                   -inkscape-font-specification: &quot;Arial, Bold&quot;;
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
-                  text-align: start;
+                  text-align: end;
                   writing-mode: rl-tb;
                   direction: rtl;
                   white-space: pre;
@@ -312,50 +294,35 @@
                   fill-opacity: 1;
                   stroke-width: 43.9644;
                 "
-                x="377.93076"
-                y="-18.683392"
+                x="1298.6099"
+                y="884.09052"
               >
                 <tspan
-                  x="1535.3855"
-                  y="769.50153"
-                  id="tspan5"
-                  style="
-                    font-style: normal;
-                    font-variant: normal;
-                    font-weight: bold;
-                    font-stretch: normal;
-                    font-size: 28.097px;
-                    font-family: sans-serif-serif;
-                    -inkscape-font-specification: &quot;Arial, Bold&quot;;
-                    font-variant-ligatures: normal;
-                    font-variant-caps: normal;
-                    font-variant-numeric: normal;
-                    font-variant-east-asian: normal;
-                    stroke-width: 43.9644;
-                  "
+                  id="tspan37"
+                  x="1298.6099"
+                  y="884.09052"
                 >
                   {{ sumArrowsThreeFour }}
                 </tspan>
               </text>
             </g>
-            <g id="layer3">
+            <g id="zaehlwerteArrowsOneTwo">
               <text
                 xml:space="preserve"
-                transform="scale(0.86707182,1.153307)"
-                id="node4_north_west_number_text"
+                id="zaehlwertArrowOne"
                 style="
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: sans-serif-serif;
+                  font-size: 24.6944px;
+                  font-family:Roboto, Arial, Helvetica, sans-serif;
                   -inkscape-font-specification: &quot;Arial, Normal&quot;;
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
-                  text-align: start;
+                  text-align: end;
                   writing-mode: rl-tb;
                   direction: rtl;
                   white-space: pre;
@@ -364,53 +331,38 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 "
-                x="-985.63147"
-                y="-300.35461"
+                x="158.24681"
+                y="562.0257"
               >
                 <tspan
-                  x="171.3958"
-                  y="487.53894"
-                  id="node4_north_west_number_tspan"
-                  style="
-                    font-style: normal;
-                    font-variant: normal;
-                    font-weight: normal;
-                    font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: sans-serif-serif;
-                    -inkscape-font-specification: &quot;Arial, Normal&quot;;
-                    font-variant-ligatures: normal;
-                    font-variant-caps: normal;
-                    font-variant-numeric: normal;
-                    font-variant-east-asian: normal;
-                    stroke-width: 43.9482;
-                  "
+                  id="tspan36"
+                  x="158.24681"
+                  y="562.0257"
                 >
-                  {{ zaehlwertArrowOne }}
+                  123456
                 </tspan>
               </text>
               <path
                 style="fill: #000000; fill-opacity: 1; stroke-width: 29.8746"
-                d="m 50.47,621.25 h 98 v 2.45 h -98 z"
-                id="path5"
+                d="M 59.530403,619.40436 H 157.5304 v 2.45 H 59.530403 Z"
+                id="separatorOneTwo"
               />
               <text
                 xml:space="preserve"
-                transform="scale(0.86707182,1.153307)"
-                id="node4_north_east_number_text"
+                id="zaehlwertArrowTwo"
                 style="
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: sans-serif-serif;
+                  font-size: 24.6944px;
+                  font-family:Roboto, Arial, Helvetica, sans-serif;
                   -inkscape-font-specification: &quot;Arial, Normal&quot;;
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
-                  text-align: start;
+                  text-align: end;
                   writing-mode: rl-tb;
                   direction: rtl;
                   white-space: pre;
@@ -419,48 +371,33 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 "
-                x="-985.63147"
-                y="-251.79846"
+                x="158.83165"
+                y="615.81903"
               >
                 <tspan
-                  x="171.3958"
-                  y="536.09497"
-                  id="node4_north_east_number_tspan"
-                  style="
-                    font-style: normal;
-                    font-variant: normal;
-                    font-weight: normal;
-                    font-stretch: normal;
-                    font-size: 28.0866px;
-                    font-family: sans-serif-serif;
-                    -inkscape-font-specification: &quot;Arial, Normal&quot;;
-                    font-variant-ligatures: normal;
-                    font-variant-caps: normal;
-                    font-variant-numeric: normal;
-                    font-variant-east-asian: normal;
-                    stroke-width: 43.9482;
-                  "
+                  id="tspan35"
+                  x="158.83165"
+                  y="615.81903"
                 >
-                  {{ zaehlwertArrowTwo }}
+                  123456
                 </tspan>
               </text>
               <text
                 xml:space="preserve"
-                transform="scale(0.86675167,1.153733)"
-                id="node4_north_sum_text"
+                id="sumArrowsOneTwo"
                 style="
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: sans-serif-serif;
+                  font-size: 24.6944px;
+                  font-family:Roboto, Arial, Helvetica, sans-serif;
                   -inkscape-font-specification: &quot;Arial, Bold&quot;;
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
-                  text-align: start;
+                  text-align: end;
                   writing-mode: rl-tb;
                   direction: rtl;
                   white-space: pre;
@@ -469,27 +406,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9644;
                 "
-                x="-985.15863"
-                y="-224.97026"
+                x="158.26794"
+                y="642.70013"
               >
                 <tspan
-                  x="172.29607"
-                  y="563.21466"
-                  id="node4_north_sum_tspan"
-                  style="
-                    font-style: normal;
-                    font-variant: normal;
-                    font-weight: bold;
-                    font-stretch: normal;
-                    font-size: 28.097px;
-                    font-family: sans-serif-serif;
-                    -inkscape-font-specification: &quot;Arial, Bold&quot;;
-                    font-variant-ligatures: normal;
-                    font-variant-caps: normal;
-                    font-variant-numeric: normal;
-                    font-variant-east-asian: normal;
-                    stroke-width: 43.9644;
-                  "
+                  id="tspan34"
+                  x="158.26794"
+                  y="642.70013"
                 >
                   {{ sumArrowsOneTwo }}
                 </tspan>
@@ -497,21 +420,20 @@
             </g>
             <text
               xml:space="preserve"
-              transform="scale(0.86675167,1.153733)"
-              id="node4_sum_text"
+              id="sumArrowsOneToFourRight"
               style="
                 font-style: normal;
                 font-variant: normal;
                 font-weight: bold;
                 font-stretch: normal;
-                font-size: 28.097px;
-                font-family: sans-serif-serif;
+                font-size: 24.6944px;
+                font-family:Roboto, Arial, Helvetica, sans-serif;
                 -inkscape-font-specification: &quot;Arial, Bold&quot;;
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
                 font-variant-east-asian: normal;
-                text-align: start;
+                text-align: end;
                 writing-mode: rl-tb;
                 direction: rtl;
                 white-space: pre;
@@ -520,48 +442,33 @@
                 fill-opacity: 1;
                 stroke-width: 43.9644;
               "
-              x="377.93076"
-              y="-171.53239"
+              x="1297.9579"
+              y="708.37695"
             >
               <tspan
-                x="1535.3855"
-                y="616.65204"
-                id="node4_sum_tspan"
-                style="
-                  font-style: normal;
-                  font-variant: normal;
-                  font-weight: bold;
-                  font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: sans-serif-serif;
-                  -inkscape-font-specification: &quot;Arial, Bold&quot;;
-                  font-variant-ligatures: normal;
-                  font-variant-caps: normal;
-                  font-variant-numeric: normal;
-                  font-variant-east-asian: normal;
-                  stroke-width: 43.9644;
-                "
+                id="tspan33"
+                x="1297.9579"
+                y="708.37695"
               >
                 {{ sumArrowsOneToFour }}
               </tspan>
             </text>
             <text
               xml:space="preserve"
-              transform="scale(0.86675167,1.153733)"
-              id="text2"
+              id="sumArrowsOneToFourLeft"
               style="
                 font-style: normal;
                 font-variant: normal;
                 font-weight: bold;
                 font-stretch: normal;
-                font-size: 28.097px;
-                font-family: sans-serif-serif;
+                font-size: 24.6944px;
+                font-family:Roboto, Arial, Helvetica, sans-serif;
                 -inkscape-font-specification: &quot;Arial, Bold&quot;;
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
                 font-variant-east-asian: normal;
-                text-align: start;
+                text-align: end;
                 writing-mode: rl-tb;
                 direction: rtl;
                 white-space: pre;
@@ -570,27 +477,13 @@
                 fill-opacity: 1;
                 stroke-width: 43.9644;
               "
-              x="-985.15863"
-              y="-171.53239"
+              x="158.22824"
+              y="707.44586"
             >
               <tspan
-                x="172.29607"
-                y="616.65204"
-                id="tspan2"
-                style="
-                  font-style: normal;
-                  font-variant: normal;
-                  font-weight: bold;
-                  font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: sans-serif-serif;
-                  -inkscape-font-specification: &quot;Arial, Bold&quot;;
-                  font-variant-ligatures: normal;
-                  font-variant-caps: normal;
-                  font-variant-numeric: normal;
-                  font-variant-east-asian: normal;
-                  stroke-width: 43.9644;
-                "
+                id="tspan32"
+                x="158.22824"
+                y="707.44586"
               >
                 {{ sumArrowsOneToFour }}
               </tspan>
@@ -611,7 +504,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: 19.7556px;
-                font-family: sans-serif;
+                font-family: Roboto, Arial, Helvetica, sans-serif;
                 -inkscape-font-specification: &quot;Sans, Normal&quot;;
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -636,14 +529,14 @@
               <tspan
                 x="168.24969"
                 y="1230.3373"
-                id="tspan8"
+                id="tspan2"
               >
                 <tspan
                   style="
                     font-weight: bold;
                     -inkscape-font-specification: &quot;Sans Bold&quot;;
                   "
-                  id="tspan7"
+                  id="tspan1"
                 >
                   {{ optionen.radverkehr ? "RAD" : "FUSS" }}
                 </tspan>
@@ -662,7 +555,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: 19.7556px;
-                  font-family: sans-serif;
+                  font-family: Roboto, Arial, Helvetica, sans-serif;
                   -inkscape-font-specification: &quot;Sans, Normal&quot;;
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -686,7 +579,7 @@
                 <tspan
                   x="168"
                   y="1210"
-                  id="tspan9"
+                  id="tspan3"
                 >
                   {{ zaehlzeit2 }}
                 </tspan>
@@ -704,7 +597,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: 19.7556px;
-                  font-family: sans-serif;
+                  font-family: Roboto, Arial, Helvetica, sans-serif;
                   -inkscape-font-specification: &quot;Sans, Normal&quot;;
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -729,14 +622,14 @@
                 <tspan
                   x="168.24969"
                   y="1190.3373"
-                  id="tspan11"
+                  id="tspan5"
                 >
                   <tspan
                     style="
                       font-weight: bold;
                       -inkscape-font-specification: &quot;Sans Bold&quot;;
                     "
-                    id="tspan10"
+                    id="tspan4"
                   >
                     {{ optionen.zeitauswahl }}
                   </tspan>
@@ -826,7 +719,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: 28.6128px;
-                  font-family: sans-serif;
+                  font-family: Roboto, Arial, Helvetica, sans-serif;
                   -inkscape-font-specification: &quot;Sans, Normal&quot;;
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -851,7 +744,7 @@
                 <tspan
                   x="699.24969"
                   y="688.33734"
-                  id="tspan12"
+                  id="tspan7"
                 >
                   {{ highestZaehlwertRounded / 2 }}
                 </tspan>
@@ -870,7 +763,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: 28.6128px;
-                  font-family: sans-serif;
+                  font-family: Roboto, Arial, Helvetica, sans-serif;
                   -inkscape-font-specification: &quot;Sans, Normal&quot;;
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -895,7 +788,7 @@
                 <tspan
                   x="699.24969"
                   y="688.33734"
-                  id="tspan13"
+                  id="tspan8"
                 >
                   {{ highestZaehlwertRounded }}
                 </tspan>
@@ -910,7 +803,7 @@
                 stroke-miterlimit: 2.5;
                 stroke-dasharray: none;
               "
-              d="m 1244.823,1240.0379 c 0.4871,10.937 0.4871,10.8003 0.4871,10.8003 v 0"
+              d="m 1244.9784,1240.0379 c 0.1622,10.937 0.1662,10.8003 0.1662,10.8003 v 0"
               id="massstab-path2"
             />
             <path
@@ -944,7 +837,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: 19.7556px;
-                  font-family: sans-serif;
+                  font-family: Roboto, Arial, Helvetica, sans-serif;
                   -inkscape-font-specification: &quot;Sans, Normal&quot;;
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -969,15 +862,15 @@
                 <tspan
                   x="699.24969"
                   y="688.33734"
-                  id="tspan14"
+                  id="tspan9"
                 >
                   Stadtbezirk
                   {{ zaehlstelleStore.getZaehlstelleHeader.stadtbezirkNummer }}
                 </tspan>
                 <tspan
                   x="699.24969"
-                  y="713.03187"
-                  id="tspan16"
+                  y="713.26057"
+                  id="tspan10"
                 >
                   Zähldatum:
                   {{
@@ -1001,7 +894,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: 19.7556px;
-                  font-family: sans-serif;
+                  font-family: Roboto, Arial, Helvetica, sans-serif;
                   -inkscape-font-specification: &quot;Sans, Normal&quot;;
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -1026,14 +919,14 @@
                 <tspan
                   x="699.24969"
                   y="688.33734"
-                  id="tspan18"
+                  id="tspan12"
                 >
                   <tspan
                     style="
                       font-weight: bold;
                       -inkscape-font-specification: &quot;Sans Bold&quot;;
                     "
-                    id="tspan17"
+                    id="tspan11"
                   >
                     Zählstelle
                     {{ zaehlstelleStore.getZaehlstelleHeader.nummer }}
@@ -1145,10 +1038,10 @@ const transformArrowFour = computed(() =>
 );
 
 // --- Pfad-Daten
-const dArrowOne = "m 245,567 v -28 h 945 v 27.998 z";
-const dArrowTwo = "m 210,623 v -28 h 945 v 27.997 z";
-const dArrowThree = "m 245,804.99999 v -28 h 945 v 27.997 z";
-const dArrowFour = "m 210,860.99999 v -28 h 945 v 27.997 z";
+const dArrowOne = "m 245,567 v -28 h 910.7202 v 27.998 z";
+const dArrowTwo = "m 245.31124,623 v -28 h 909.68866 v 27.997 z";
+const dArrowThree = "m 245,804.99999 v -28 h 910.1007 v 27.997 z";
+const dArrowFour = "m 244.89933,860.99999 v -28 H 1155 v 27.997 z";
 
 const activeZaehlung = computed<LadeZaehlungDTO>(() => {
   return zaehlstelleStore.getAktiveZaehlung;

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
@@ -31,7 +31,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -64,7 +64,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -193,7 +193,7 @@
                 font-weight: bold;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -227,7 +227,7 @@
                 font-weight: bold;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -262,7 +262,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -296,7 +296,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -376,7 +376,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -410,7 +410,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -449,7 +449,7 @@
                   font-weight: bold;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -552,7 +552,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -600,7 +600,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -659,7 +659,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -705,7 +705,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -742,7 +742,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth}px;
-                font-familiy: ${BelastungsplanConstants.fontfamily};
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -815,7 +815,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -857,7 +857,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth}px;
-                  font-familiy: ${BelastungsplanConstants.fontfamily};
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
@@ -30,7 +30,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -63,7 +63,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -192,7 +192,7 @@
                 font-variant: normal;
                 font-weight: bold;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -226,7 +226,7 @@
                 font-variant: normal;
                 font-weight: bold;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -261,7 +261,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -295,7 +295,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -339,7 +339,7 @@
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-family: ${belastungsplanMethods.maxlineWidth};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -375,7 +375,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -409,7 +409,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -448,7 +448,7 @@
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -487,7 +487,7 @@
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-family: sans-serif;
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -501,7 +501,7 @@
                 stroke-width: 2.2868;
               `"
               x="100.26942"
-              y="84.035934"
+              y="83.035934"
             >
               <tspan
                 :style="`
@@ -509,7 +509,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -551,7 +551,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -599,7 +599,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -618,11 +618,11 @@
                 `"
                 id="zaehlstelle2-multirow"
                 x="1107.2496"
-                y="85.837341"
+                y="86.837341"
               >
                 <tspan
                   x="1107.2496"
-                  y="85.837341"
+                  y="86.837341"
                   id="tspan17"
                 >
                   Stadtbezirk
@@ -658,7 +658,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -704,7 +704,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -741,7 +741,7 @@
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-familiy: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -814,7 +814,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
@@ -856,7 +856,7 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: ${belastungsplanMethods.maxlineWidth};
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
@@ -208,12 +208,12 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="1298.7062"
+                x="1288.7062"
                 y="799.76965"
               >
                 <tspan
                   id="tspan39"
-                  x="1298.7062"
+                  x="1288.7062"
                   y="799.76965"
                 >
                   {{ zaehlwertArrowThree }}
@@ -242,12 +242,12 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="1298.0775"
+                x="1288.0775"
                 y="855.68152"
               >
                 <tspan
                   id="tspan38"
-                  x="1298.0775"
+                  x="1288.0775"
                   y="855.68152"
                 >
                   {{ zaehlwertArrowFour }}
@@ -281,12 +281,12 @@
                   fill-opacity: 1;
                   stroke-width: 43.9644;
                 `"
-                x="1298.6099"
+                x="1288.6099"
                 y="884.09052"
               >
                 <tspan
                   id="tspan37"
-                  x="1298.6099"
+                  x="1288.6099"
                   y="884.09052"
                 >
                   {{ sumArrowsThreeFour }}
@@ -317,12 +317,12 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="158.24681"
+                x="215.24681"
                 y="562.0257"
               >
                 <tspan
                   id="tspan36"
-                  x="158.24681"
+                  x="215.24681"
                   y="562.0257"
                 >
                   {{ zaehlwertArrowOne }}
@@ -330,7 +330,7 @@
               </text>
               <path
                 style="fill: #000000; fill-opacity: 1; stroke-width: 29.8746"
-                d="M 59.530403,619.40436 H 157.5304 v 2.45 H 59.530403 Z"
+                d="m 116.95317,618.45522 h 97.99999 v 1.0263 h -97.99999 z"
                 id="separatorOneTwo"
               />
               <text
@@ -356,12 +356,12 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="158.83165"
+                x="215.83165"
                 y="615.81903"
               >
                 <tspan
                   id="tspan35"
-                  x="158.83165"
+                  x="215.83165"
                   y="615.81903"
                 >
                   {{ zaehlwertArrowTwo }}
@@ -390,12 +390,12 @@
                   fill-opacity: 1;
                   stroke-width: 43.9644;
                 `"
-                x="158.26794"
+                x="215.26794"
                 y="642.70013"
               >
                 <tspan
                   id="tspan34"
-                  x="158.26794"
+                  x="215.26794"
                   y="642.70013"
                 >
                   {{ sumArrowsOneTwo }}
@@ -425,12 +425,12 @@
                 fill-opacity: 1;
                 stroke-width: 43.9644;
               `"
-              x="1297.9579"
+              x="1288.9579"
               y="708.37695"
             >
               <tspan
                 id="tspan33"
-                x="1297.9579"
+                x="1288.9579"
                 y="708.37695"
               >
                 {{ sumArrowsOneToFour }}
@@ -459,12 +459,12 @@
                 fill-opacity: 1;
                 stroke-width: 43.9644;
               `"
-              x="158.22824"
+              x="215.22824"
               y="707.44586"
             >
               <tspan
                 id="tspan32"
-                x="158.22824"
+                x="215.22824"
                 y="707.44586"
               >
                 {{ sumArrowsOneToFour }}
@@ -476,7 +476,6 @@
           <g
             id="legend-zaehlinfo"
             style="stroke-width: 28.2205; stroke-dasharray: none"
-            transform="translate(50.006244,31.659644)"
           >
             <text
               xml:space="preserve"
@@ -503,13 +502,12 @@
                 stroke-dasharray: none;
               `"
               id="verkehrsart"
-              x="168.24969"
-              y="1230.3373"
-              transform="matrix(1.000004,0,0,1,-152.56418,35.000043)"
+              x="56.24969"
+              y="1310.3373"
             >
               <tspan
-                x="168.24969"
-                y="1230.3373"
+                x="56.24969"
+                y="1310.3373"
                 id="tspan2"
               >
                 <tspan
@@ -523,7 +521,6 @@
             <g
               id="zaehlzeit2"
               style="stroke-width: 28.2205; stroke-dasharray: none"
-              transform="translate(-152.29421)"
             >
               <text
                 xml:space="preserve"
@@ -550,12 +547,12 @@
                   stroke-dasharray: none;
                 `"
                 id="zaehlzeit2-multirow"
-                x="168"
-                y="1210"
+                x="56.24969"
+                y="1257"
               >
                 <tspan
-                  x="168"
-                  y="1210"
+                  x="56.24969"
+                  y="1257"
                   id="tspan3"
                 >
                   {{ zaehlzeit2 }}
@@ -591,13 +588,12 @@
                   stroke-dasharray: none;
                 `"
                 id="zaehlzeit1-multirow"
-                x="168.24969"
-                y="1190.3373"
-                transform="translate(-150.84646,0.00162031)"
+                x="56.24969"
+                y="1231.3373"
               >
                 <tspan
-                  x="168.24969"
-                  y="1190.3373"
+                  x="56.24969"
+                  y="1231.3373"
                   id="tspan5"
                 >
                   <tspan
@@ -612,22 +608,20 @@
           </g>
           <g
             id="legend-compass"
-            transform="matrix(0.79169692,0,0,0.78817168,-25.092397,5.5190685)"
           >
             <path
-              style="
+              :style="`
                 fill: none;
                 fill-opacity: 1;
-                stroke: #000000;
-                stroke-width: 3.35093;
+                stroke: ${BelastungsplanConstants.legendColor};
+                stroke-width: 2.05093;
                 stroke-linecap: butt;
                 stroke-miterlimit: 2.5;
                 stroke-dasharray: none;
                 stroke-opacity: 1;
-              "
+              `"
               id="compass2"
-              d="m 399.4343,-24.60083 105.23313,182.26914 -210.46627,-1e-5 z"
-              transform="matrix(0.16996929,0,0,0.4104001,81.91578,36.842952)"
+              d="m 107.4337,29.986817 13.91905,63.782102 H 106.06633 93.514636 Z"
             />
             <text
               xml:space="preserve"
@@ -638,7 +632,7 @@
                 font-weight: normal;
                 font-stretch: normal;
                 font-size: ${belastungsplanMethods.maxlineWidth};
-                font-family: RomanD;
+                font-family: sans-serif;
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -647,11 +641,11 @@
                 writing-mode: lr-tb;
                 direction: ltr;
                 text-anchor: start;
-                fill: #000000;
+                fill: ${BelastungsplanConstants.legendColor};
                 stroke-width: 2.2868;
               `"
-              x="141.28348"
-              y="93.924416"
+              x="100.269417"
+              y="84.061363"
             >
               <tspan
                 :style="`
@@ -660,7 +654,7 @@
                   font-weight: normal;
                   font-stretch: normal;
                   font-size: ${belastungsplanMethods.maxlineWidth};
-                  font-family: RomanD;
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -675,12 +669,10 @@
           </g>
           <g
             id="legend-massstab"
-            transform="translate(-18.042256,33.984156)"
           >
             <g
               id="massstab-size1"
               style="stroke-width: 28.2205; stroke-dasharray: none"
-              transform="matrix(0.62382516,0,0,0.76417899,670.41706,744.80969)"
             >
               <text
                 xml:space="preserve"
@@ -689,16 +681,16 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.6128px;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
-                  text-align: start;
+                  text-align: center;
                   writing-mode: lr-tb;
                   direction: ltr;
-                  text-anchor: start;
+                  text-anchor: middle;
                   white-space: pre;
                   inline-size: 268.729;
                   display: inline;
@@ -707,13 +699,12 @@
                   stroke-dasharray: none;
                 `"
                 id="massstab-size1-multirow"
-                x="699.24969"
-                y="688.33734"
-                transform="translate(181.39362,6.9760325e-4)"
+                x="1250.2496"
+                y="1315.3373"
               >
                 <tspan
-                  x="699.24969"
-                  y="688.33734"
+                  x="1250.2496"
+                  y="1315.3373"
                   id="tspan7"
                 >
                   {{ highestZaehlwertRounded / 2 }}
@@ -723,7 +714,6 @@
             <g
               id="massstab-size2"
               style="stroke-width: 28.2205; stroke-dasharray: none"
-              transform="matrix(0.62382516,0,0,0.76417899,423.85279,750.20592)"
             >
               <text
                 xml:space="preserve"
@@ -732,16 +722,16 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.6128px;
+                  font-size: ${belastungsplanMethods.maxlineWidth};
                   font-familiy: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
-                  text-align: start;
+                  text-align: center;
                   writing-mode: lr-tb;
                   direction: ltr;
-                  text-anchor: start;
+                  text-anchor: middle;
                   white-space: pre;
                   inline-size: 268.729;
                   display: inline;
@@ -750,13 +740,12 @@
                   stroke-dasharray: none;
                 `"
                 id="massstab-size2-multirow"
-                x="699.24969"
-                y="688.33734"
-                transform="translate(670.97788,-7.8186747)"
+                x="1316.2496"
+                y="1315.3373"
               >
                 <tspan
-                  x="699.24969"
-                  y="688.33734"
+                    x="1316.2496"
+                    y="1315.3373"
                   id="tspan8"
                 >
                   {{ highestZaehlwertRounded }}
@@ -767,35 +756,33 @@
               style="
                 fill: #000000;
                 stroke: #000000;
-                stroke-width: 0.802209;
+                stroke-width: 1.580777;
                 stroke-linecap: square;
                 stroke-miterlimit: 2.5;
                 stroke-dasharray: none;
               "
-              d="m 1244.9784,1240.0379 c 0.1622,10.937 0.1662,10.8003 0.1662,10.8003 v 0"
+              d="m 1252.7468,1284.8273 c 0.1805,8.9058 0.185,8.7945 0.185,8.7945 v 0"
               id="massstab-path2"
             />
             <path
-              style="
+              :style="`
                 fill: none;
-                stroke: #000000;
-                stroke-width: 0.880777;
+                stroke: ${BelastungsplanConstants.legendColor};
+                stroke-width: 2.000000;
                 stroke-linecap: square;
                 stroke-miterlimit: 2.5;
                 stroke-dasharray: none;
-              "
-              d="m 1300.4928,1251.6987 -119.9017,-0.2413 119.9017,-22.432 z"
-              id="path6"
+              `"
+              d="m 1316.5243,1294.7302 -124.9982,-0.2134 124.9982,-19.8383 z"
+              id="massstab-path1"
             />
           </g>
           <g
             id="legend-zaehlstelle"
-            transform="translate(-112.62637,-13.999124)"
           >
             <g
               id="zaehlstelle2"
               style="stroke-width: 28.2205; stroke-dasharray: none"
-              transform="translate(163.18555,-589.09456)"
             >
               <text
                 v-if="zaehlstelleStore.getZaehlstelleHeader.stadtbezirkNummer"
@@ -823,21 +810,20 @@
                   stroke-dasharray: none;
                 `"
                 id="zaehlstelle2-multirow"
-                x="699.24969"
-                y="688.33734"
-                transform="translate(324.11416)"
+                x="1107.24969"
+                y="86.33734"
               >
                 <tspan
-                  x="699.24969"
-                  y="688.33734"
+                  x="1107.24969"
+                  y="86.33734"
                   id="tspan9"
                 >
                   Stadtbezirk
                   {{ zaehlstelleStore.getZaehlstelleHeader.stadtbezirkNummer }}
                 </tspan>
                 <tspan
-                  x="699.24969"
-                  y="713.26057"
+                  x="1107.24969"
+                  y="112.26057"
                   id="tspan10"
                 >
                   Zähldatum:
@@ -852,7 +838,6 @@
             <g
               id="zaehlstelle1"
               style="stroke-width: 28.2205; stroke-dasharray: none"
-              transform="translate(162.09712,-614.70735)"
             >
               <text
                 xml:space="preserve"
@@ -879,13 +864,12 @@
                   stroke-dasharray: none;
                 `"
                 id="zaehlstelle1-multirow"
-                x="699.24969"
-                y="688.33734"
-                transform="translate(324.11416)"
+                x="1107.24969"
+                y="60.33734"
               >
                 <tspan
-                  x="699.24969"
-                  y="688.33734"
+                  x="1107.24969"
+                  y="60.33734"
                   id="tspan12"
                 >
                   <tspan


### PR DESCRIPTION
# Description

<!-- Add a short description of what the request is all about here -->
Fonts, coords and arrow tips adjusted

# Issue References

<!-- Add the corresponding issues here -->
FV-354
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [x] Acceptance criteria are met
- [ ] Testing is done (unit-tests, DEV-environment)
- [ ] Build/Test workflow has successfully finished
- [ ] Release notes are complemented
- [ ] Documentation is complemented (operator manual, system specification, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Legend now displays additional traffic count information, dates, and header details.

* **Improvements**
  * Arrow scaling increased for better visibility.
  * Font sizing dynamically adapts to content; street names support multi-line rendering.
  * Arrow shapes and rendering refined for improved visual representation.
  * Legend styling consolidated with a unified legend color.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/it-at-m/dave-frontend/pull/614?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->