### PR TITLE
FV-373 BLP Schriftart bei FjS und Qu nicht wie bei bestehenden Zaehlarten

### DIFF
--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanFjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanFjsSvg.vue
@@ -15,14 +15,10 @@
       xmlns:svg="http://www.w3.org/2000/svg"
     >
       <defs id="defs1" />
-      <g
-        id="legend"
-        transform="translate(9.0201068e-4,-7.1314694e-4)"
-      >
+      <g id="legend">
         <g
           id="legend-zaehlinfo"
           style="stroke-width: 28.2205; stroke-dasharray: none"
-          transform="translate(50.006244,31.659644)"
         >
           <text
             id="verkehrsart"
@@ -32,7 +28,7 @@
               font-variant: normal;
               font-weight: normal;
               font-stretch: normal;
-              font-size: ${belastungsplanMethods.maxlineWidth};
+              font-size: ${belastungsplanMethods.maxlineWidth}px;
               font-family: ${BelastungsplanConstants.fontfamily};
               font-variant-ligatures: normal;
               font-variant-caps: normal;
@@ -49,14 +45,13 @@
               stroke-width: 28.2205;
               stroke-dasharray: none;
             `"
-            x="168.24969"
-            y="1230.3373"
-            transform="matrix(1.000004,0,0,1,-152.56418,35.000043)"
+            x="56.249691"
+            y="1310.3373"
           >
             <tspan
               id="tspan13"
-              x="168.24969"
-              y="1230.3373"
+              x="56.249691"
+              y="1310.3373"
             >
               <tspan
                 id="tspan12"
@@ -69,7 +64,6 @@
           <g
             id="zaehlzeit2"
             style="stroke-width: 28.2205; stroke-dasharray: none"
-            transform="translate(-152.29421)"
           >
             <text
               id="zaehlzeit2-multirow"
@@ -79,7 +73,7 @@
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: ${belastungsplanMethods.maxlineWidth};
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
                 font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
@@ -96,13 +90,13 @@
                 stroke-width: 28.2205;
                 stroke-dasharray: none;
               `"
-              x="168"
-              y="1210"
+              x="56.249691"
+              y="1257"
             >
               <tspan
                 id="tspan18"
-                x="168"
-                y="1210"
+                x="56.249691"
+                y="1257"
               >
                 {{ zaehlzeit2 }}
               </tspan>
@@ -137,14 +131,13 @@
                 stroke-width: 28.2205;
                 stroke-dasharray: none;
               `"
-              x="168.24969"
-              y="1190.3373"
-              transform="translate(-150.84646,0.00360406)"
+              x="56.249691"
+              y="1230.3373"
             >
               <tspan
                 id="tspan20"
-                x="168.24969"
-                y="1190.3373"
+                x="56.249691"
+                y="1230.3373"
               >
                 <tspan
                   id="tspan19"
@@ -156,24 +149,20 @@
             </text>
           </g>
         </g>
-        <g
-          id="legend-compass"
-          transform="matrix(0.79169692,0,0,0.78817168,-25.092397,5.5190685)"
-        >
+        <g id="legend-compass">
           <path
             id="compass2"
             style="
               fill: none;
               fill-opacity: 1;
-              stroke: #000000;
-              stroke-width: 3.35093;
+              stroke: #666666;
+              stroke-width: 1.99499999;
               stroke-linecap: butt;
               stroke-miterlimit: 2.5;
               stroke-dasharray: none;
               stroke-opacity: 1;
             "
-            d="m 399.4343,-24.60083 105.23313,182.26914 -210.46627,-1e-5 z"
-            transform="matrix(0.16996929,0,0,0.4104001,81.91578,36.842952)"
+            d="m 107.4337,29.984176 13.9217,63.312817 H 106.06607 93.511995 Z"
           />
           <text
             id="compass1"
@@ -193,11 +182,11 @@
               writing-mode: lr-tb;
               direction: ltr;
               text-anchor: start;
-              fill: #000000;
+              fill: #666666;
               stroke-width: 2.2868;
             `"
-            x="141.28041"
-            y="93.924416"
+            x="100.26942"
+            y="84.035934"
           >
             <tspan
               id="tspan6-1"
@@ -212,21 +201,17 @@
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
                 font-variant-east-asian: normal;
-                stroke-width: 2.2868;
+                stroke-width: 43.9644;
               `"
             >
               N
             </tspan>
           </text>
         </g>
-        <g
-          id="legend-zaehlstelle"
-          transform="translate(-112.62637,-13.999124)"
-        >
+        <g id="legend-zaehlstelle">
           <g
             id="zaehlstelle2"
             style="stroke-width: 28.2205; stroke-dasharray: none"
-            transform="translate(163.18555,-589.09456)"
           >
             <text
               v-if="zaehlstelleStore.getZaehlstelleHeader.stadtbezirkNummer"
@@ -254,22 +239,21 @@
                 stroke-width: 28.2205;
                 stroke-dasharray: none;
               `"
-              x="699.24969"
-              y="688.33734"
-              transform="translate(324.11416)"
+              x="1107.2496"
+              y="85.837341"
             >
               <tspan
                 id="tspan21"
-                x="699.24969"
-                y="688.33734"
+                x="1107.2496"
+                y="85.837341"
               >
                 Stadtbezirk
                 {{ zaehlstelleStore.getZaehlstelleHeader.stadtbezirkNummer }}
               </tspan>
               <tspan
                 id="tspan22"
-                x="699.24969"
-                y="713.03187"
+                x="1107.2496"
+                y="112.26053"
               >
                 Zähldatum:
                 {{
@@ -283,7 +267,6 @@
           <g
             id="zaehlstelle1"
             style="stroke-width: 28.2205; stroke-dasharray: none"
-            transform="translate(162.09712,-614.70735)"
           >
             <text
               id="zaehlstelle1-multirow"
@@ -310,14 +293,13 @@
                 stroke-width: 28.2205;
                 stroke-dasharray: none;
               `"
-              x="699.24969"
-              y="688.33734"
-              transform="translate(324.11217)"
+              x="1107.2496"
+              y="60.337341"
             >
               <tspan
                 id="tspan24"
-                x="699.24969"
-                y="688.33734"
+                x="1107.2496"
+                y="60.337341"
               >
                 <tspan
                   id="tspan23"

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanFjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanFjsSvg.vue
@@ -152,17 +152,17 @@
         <g id="legend-compass">
           <path
             id="compass2"
-            style="
+            :style="`
               fill: none;
               fill-opacity: 1;
-              stroke: #666666;
-              stroke-width: 1.99499999;
+              stroke: ${BelastungsplanConstants.legendColor};
+              stroke-width: 2;
               stroke-linecap: butt;
               stroke-miterlimit: 2.5;
               stroke-dasharray: none;
               stroke-opacity: 1;
-            "
-            d="m 107.4337,29.984176 13.9217,63.312817 H 106.06607 93.511995 Z"
+            `"
+            d="m 93.333333,93.333333 h 27.999997 l -14,-63 z"
           />
           <text
             id="compass1"
@@ -181,12 +181,12 @@
               text-align: start;
               writing-mode: lr-tb;
               direction: ltr;
-              text-anchor: start;
-              fill: #666666;
-              stroke-width: 2.2868;
+              text-anchor: middle;
+              fill: ${BelastungsplanConstants.legendColor};
+              stroke-width: 2;
             `"
-            x="100.26942"
-            y="84.035934"
+            x="107.33477"
+            y="83.332977"
           >
             <tspan
               id="tspan6-1"
@@ -201,7 +201,7 @@
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
                 font-variant-east-asian: normal;
-                stroke-width: 43.9644;
+                stroke-width: 2;
               `"
             >
               N

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanFjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanFjsSvg.vue
@@ -506,7 +506,7 @@
             <text
               id="node1_sum_text"
               xml:space="preserve"
-              transform="matrix(0,-0.86675092,1.153734,0,0,0)"
+              transform="rotate(-90)"
               :style="`
                 font-style: normal;
                 font-variant: normal;
@@ -527,13 +527,13 @@
                 fill-opacity: 1;
                 stroke-width: 43.9645;
               `"
-              x="-1207.2531"
-              y="-171.53365"
+              x="-1200.4841"
+              y="-79.837906"
             >
               <tspan
                 id="node1_sum_tspan"
-                x="-49.797398"
-                y="616.65149"
+                x="-43.028492"
+                y="708.34723"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -574,7 +574,7 @@
                 v-if="arrowNodeOneWestIncomingAvailable"
                 id="arrow_node1_west_incoming_number_text"
                 xml:space="preserve"
-                transform="matrix(0,-0.86707182,1.153307,0,0,0)"
+                transform="rotate(-90)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -595,13 +595,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-1206.5183"
-                y="-259.38544"
+                x="-1199.7682"
+                y="-181.45634"
               >
                 <tspan
                   id="arrow_node1_west_incoming_number_tspan"
-                  x="-49.490978"
-                  y="528.50812"
+                  x="-42.740871"
+                  y="606.43726"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -623,7 +623,7 @@
                 v-if="arrowNodeOneWestOutgoingAvailable"
                 id="arrow_node1_west_outgoing_number_text"
                 xml:space="preserve"
-                transform="matrix(0,-0.86707182,1.153307,0,0,0)"
+                transform="rotate(-90)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -644,13 +644,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-1206.5183"
-                y="-230.55521"
+                x="-1199.7682"
+                y="-148.20622"
               >
                 <tspan
                   id="arrow_node1_west_outgoing_number_tspan"
-                  x="-49.490978"
-                  y="557.33826"
+                  x="-42.740871"
+                  y="639.68726"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -675,7 +675,7 @@
                 "
                 id="arrows_node1_west_sum_text"
                 xml:space="preserve"
-                transform="matrix(0,-0.86675167,1.153733,0,0,0)"
+                transform="rotate(-90)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -696,13 +696,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9644;
                 `"
-                x="-1207.2521"
-                y="-203.73477"
+                x="-1200.4833"
+                y="-116.99011"
               >
                 <tspan
                   id="arrows_node1_west_sum_tspan"
-                  x="-49.797356"
-                  y="584.45007"
+                  x="-43.028492"
+                  y="671.1947"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -751,7 +751,7 @@
                 v-if="arrowNodeOneEastIncomingAvailable"
                 id="arrow_node1_east_incoming_number_text"
                 xml:space="preserve"
-                transform="matrix(0,-0.86707182,1.153307,0,0,0)"
+                transform="rotate(-90)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -772,13 +772,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-1206.5183"
-                y="-115.23471"
+                x="-1199.7682"
+                y="-15.206282"
               >
                 <tspan
                   id="arrow_node1_east_incoming_number_tspan"
-                  x="-49.490978"
-                  y="672.65881"
+                  x="-42.740871"
+                  y="772.68726"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -800,7 +800,7 @@
                 v-if="arrowNodeOneEastOutgoingAvailable"
                 id="arrow_node1_east_outgoing_number_text"
                 xml:space="preserve"
-                transform="matrix(0,-0.86707182,1.153307,0,0,0)"
+                transform="rotate(-90)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -821,13 +821,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-1206.5183"
-                y="-86.404541"
+                x="-1199.7682"
+                y="18.043777"
               >
                 <tspan
                   id="arrow_node1_east_outgoing_number_tspan"
-                  x="-49.490978"
-                  y="701.48889"
+                  x="-42.740871"
+                  y="805.93726"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -852,7 +852,7 @@
                 "
                 id="arrows_node1_east_sum_text"
                 xml:space="preserve"
-                transform="matrix(0,-0.86675167,1.153733,0,0,0)"
+                transform="rotate(-90)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -873,13 +873,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9644;
                 `"
-                x="-1207.2521"
-                y="-59.637333"
+                x="-1200.4833"
+                y="49.25988"
               >
                 <tspan
                   id="arrows_node1_east_sum_tspan"
-                  x="-49.797356"
-                  y="728.54749"
+                  x="-43.028492"
+                  y="837.4447"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -1077,7 +1077,6 @@
             <text
               id="node2_sum_text"
               xml:space="preserve"
-              transform="scale(0.86675092,1.153734)"
               :style="`
                 font-style: normal;
                 font-variant: normal;
@@ -1098,13 +1097,13 @@
                 fill-opacity: 1;
                 stroke-width: 43.9645;
               `"
-              x="407.97421"
-              y="-171.52608"
+              x="211.57898"
+              y="-79.830925"
             >
               <tspan
                 id="node2_sum_tspan"
-                x="1565.4299"
-                y="616.65906"
+                x="1369.0348"
+                y="708.35419"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -1145,7 +1144,6 @@
                 v-if="arrowNodeTwoNorthIncomingAvailable"
                 id="arrow_node2_north_incoming_number_text"
                 xml:space="preserve"
-                transform="scale(0.86707182,1.153307)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -1166,13 +1164,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="406.98672"
-                y="-259.38541"
+                x="211.13699"
+                y="-181.45631"
               >
                 <tspan
                   id="arrow_node2_north_incoming_number_tspan"
-                  x="1564.014"
-                  y="528.50812"
+                  x="1368.1643"
+                  y="606.43726"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -1194,7 +1192,6 @@
                 v-if="arrowNodeTwoNorthOutgoingAvailable"
                 id="arrow_node2_north_outgoing_number_text"
                 xml:space="preserve"
-                transform="scale(0.86707182,1.153307)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -1215,13 +1212,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="406.98672"
-                y="-230.55528"
+                x="211.13699"
+                y="-148.2063"
               >
                 <tspan
                   id="arrow_node2_north_outgoing_number_tspan"
-                  x="1564.014"
-                  y="557.33826"
+                  x="1368.1643"
+                  y="639.68726"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -1246,7 +1243,6 @@
                 "
                 id="arrows_node2_north_sum_text"
                 xml:space="preserve"
-                transform="scale(0.86675167,1.153733)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -1267,13 +1263,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9644;
                 `"
-                x="407.97394"
-                y="-203.73479"
+                x="211.58005"
+                y="-116.99011"
               >
                 <tspan
                   id="arrows_node2_north_sum_tspan"
-                  x="1565.4286"
-                  y="584.45001"
+                  x="1369.0348"
+                  y="671.1947"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -1322,7 +1318,6 @@
                 v-if="arrowNodeTwoSouthIncomingAvailable"
                 id="arrow_node2_south_incoming_number_text"
                 xml:space="preserve"
-                transform="scale(0.86707182,1.153307)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -1343,13 +1338,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="406.98672"
-                y="-115.2347"
+                x="211.13699"
+                y="-15.206279"
               >
                 <tspan
                   id="arrow_node2_south_incoming_number_tspan"
-                  x="1564.014"
-                  y="672.65881"
+                  x="1368.1643"
+                  y="772.68726"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -1371,7 +1366,6 @@
                 v-if="arrowNodeTwoSouthOutgoingAvailable"
                 id="arrow_node2_south_outgoing_number_text"
                 xml:space="preserve"
-                transform="scale(0.86707182,1.153307)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -1392,13 +1386,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="406.98669"
-                y="-86.404564"
+                x="211.13696"
+                y="18.043781"
               >
                 <tspan
                   id="arrow_node2_south_outgoing_number_tspan"
-                  x="1564.014"
-                  y="701.48889"
+                  x="1368.1643"
+                  y="805.93726"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -1423,7 +1417,6 @@
                 "
                 id="arrows_node2_south_sum_text"
                 xml:space="preserve"
-                transform="scale(0.86675167,1.153733)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -1444,13 +1437,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9644;
                 `"
-                x="407.97397"
-                y="-59.637352"
+                x="211.57996"
+                y="49.259895"
               >
                 <tspan
                   id="arrows_node2_south_sum_tspan"
-                  x="1565.4287"
-                  y="728.54749"
+                  x="1369.0348"
+                  y="837.4447"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -1687,7 +1680,7 @@
             <text
               id="node3_sum_text"
               xml:space="preserve"
-              transform="matrix(0,-0.86675092,1.153734,0,0,0)"
+              transform="rotate(-90)"
               :style="`
                 font-style: normal;
                 font-variant: normal;
@@ -1708,13 +1701,13 @@
                 fill-opacity: 1;
                 stroke-width: 43.9645;
               `"
-              x="-2630.3494"
-              y="-171.53365"
+              x="-2433.9543"
+              y="-79.837982"
             >
               <tspan
                 id="node3_sum_tspan"
-                x="-1472.8937"
-                y="616.65149"
+                x="-1276.4985"
+                y="708.34723"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -1755,7 +1748,7 @@
                 v-if="arrowNodeThreeEastOutgoingAvailable"
                 id="arrow_node3_east_incoming_number_text"
                 xml:space="preserve"
-                transform="matrix(0,-0.86707182,1.153307,0,0,0)"
+                transform="rotate(-90)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -1776,13 +1769,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-2629.0879"
-                y="-115.23471"
+                x="-2433.238"
+                y="-15.206213"
               >
                 <tspan
                   id="arrow_node3_east_incoming_number_tspan"
-                  x="-1472.0605"
-                  y="672.65881"
+                  x="-1276.2108"
+                  y="772.68726"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -1804,7 +1797,7 @@
                 v-if="arrowNodeThreeEastIncomingAvailable"
                 id="arrow_node3_east_outgoing_number_text"
                 xml:space="preserve"
-                transform="matrix(0,-0.86707182,1.153307,0,0,0)"
+                transform="rotate(-90)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -1825,13 +1818,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-2629.0879"
-                y="-86.404541"
+                x="-2433.238"
+                y="18.043785"
               >
                 <tspan
                   id="arrow_node3_east_outgoing_number_tspan"
-                  x="-1472.0605"
-                  y="701.48889"
+                  x="-1276.2108"
+                  y="805.93726"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -1856,7 +1849,7 @@
                 "
                 id="arrows_node3_east_sum_text"
                 xml:space="preserve"
-                transform="matrix(0,-0.86675167,1.153733,0,0,0)"
+                transform="rotate(-90)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -1877,13 +1870,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9644;
                 `"
-                x="-2630.3472"
-                y="-59.637333"
+                x="-2433.9534"
+                y="49.259911"
               >
                 <tspan
                   id="arrows_node3_east_sum_tspan"
-                  x="-1472.8923"
-                  y="728.54749"
+                  x="-1276.4985"
+                  y="837.4447"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -1932,7 +1925,7 @@
                 v-if="arrowNodeThreeWestOutgoingAvailable"
                 id="arrow_node3_west_outgoing_number_text"
                 xml:space="preserve"
-                transform="matrix(0,-0.86707182,1.153307,0,0,0)"
+                transform="rotate(-90)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -1953,13 +1946,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-2629.0879"
-                y="-259.38544"
+                x="-2433.2383"
+                y="-181.45621"
               >
                 <tspan
                   id="arrow_node3_west_outgoing_number_tspan"
-                  x="-1472.0605"
-                  y="528.50812"
+                  x="-1276.2108"
+                  y="606.43726"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -1981,7 +1974,7 @@
                 v-if="arrowNodeThreeWestIncomingAvailable"
                 id="arrow_node3_west_incoming_number_text"
                 xml:space="preserve"
-                transform="matrix(0,-0.86707182,1.153307,0,0,0)"
+                transform="rotate(-90)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -2002,13 +1995,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-2629.0879"
-                y="-230.55521"
+                x="-2433.2383"
+                y="-148.20621"
               >
                 <tspan
                   id="arrow_node3_west_incoming_number_tspan"
-                  x="-1472.0605"
-                  y="557.33826"
+                  x="-1276.2108"
+                  y="639.68726"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -2033,7 +2026,7 @@
                 "
                 id="arrows_node3_west_sum_text"
                 xml:space="preserve"
-                transform="matrix(0,-0.86675167,1.153733,0,0,0)"
+                transform="rotate(-90)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -2054,13 +2047,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9644;
                 `"
-                x="-2630.3472"
-                y="-203.73477"
+                x="-2433.9534"
+                y="-116.99008"
               >
                 <tspan
                   id="arrows_node3_west_sum_tspan"
-                  x="-1472.8923"
-                  y="584.45007"
+                  x="-1276.4985"
+                  y="671.1947"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -2307,19 +2300,19 @@
                 font-variant-east-asian: normal;
                 text-align: start;
                 writing-mode: rl-tb;
-                direction: ltr;
+                direction: rtl;
                 white-space: pre;
                 display: inline;
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 43.9644;
               `"
-              x="-1034.2489"
-              y="-78.905891"
+              x="-1021.89"
+              y="-79.830223"
             >
               <tspan
-                x="123.20578"
-                y="709.27856"
+                x="135.56476"
+                y="708.35419"
                 id="node4_sum_tspan"
                 :style="`
                   font-style: normal;
@@ -2361,7 +2354,6 @@
                 v-if="arrowNodeFourSouthOutgoingAvailable"
                 id="arrow_node4_south_outgoing_number_text"
                 xml:space="preserve"
-                transform="scale(0.86707182,1.153307)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -2382,13 +2374,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-1015.5829"
-                y="-115.2348"
+                x="-1022.333"
+                y="-15.206355"
               >
                 <tspan
                   id="arrow_node4_south_outgoing_number_tspan"
-                  x="141.44441"
-                  y="672.65881"
+                  x="134.69431"
+                  y="772.68726"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -2410,7 +2402,6 @@
                 v-if="arrowNodeFourSouthIncomingAvailable"
                 id="arrow_node4_south_incoming_number_text"
                 xml:space="preserve"
-                transform="scale(0.86707182,1.153307)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -2431,13 +2422,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-1015.5829"
-                y="-86.404541"
+                x="-1022.333"
+                y="18.043804"
               >
                 <tspan
                   id="arrow_node4_south_incoming_number_tspan"
-                  x="141.44441"
-                  y="701.48889"
+                  x="134.69431"
+                  y="805.93726"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -2462,7 +2453,6 @@
                 "
                 id="arrows_node4_south_sum_text"
                 xml:space="preserve"
-                transform="scale(0.86675167,1.153733)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -2483,13 +2473,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9644;
                 `"
-                x="-1015.1211"
-                y="-59.637363"
+                x="-1021.89"
+                y="49.259884"
               >
                 <tspan
                   id="arrows_node4_south_sum_tspan"
-                  x="142.33362"
-                  y="728.54749"
+                  x="135.56476"
+                  y="837.4447"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -2538,7 +2528,6 @@
                 v-if="arrowNodeFourNorthOutgoingAvailable"
                 id="arrow_node4_north_outgoing_number_text"
                 xml:space="preserve"
-                transform="scale(0.86707182,1.153307)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -2559,13 +2548,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-1015.5829"
-                y="-259.38544"
+                x="-1022.333"
+                y="-181.45634"
               >
                 <tspan
                   id="arrow_node4_north_outgoing_number_tspan"
-                  x="141.44441"
-                  y="528.50812"
+                  x="134.69431"
+                  y="606.43726"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -2587,7 +2576,6 @@
                 v-if="arrowNodeFourNorthIncomingAvailable"
                 id="arrow_node4_north_incoming_number_text"
                 xml:space="preserve"
-                transform="scale(0.86707182,1.153307)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -2608,13 +2596,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-1015.5829"
-                y="-230.55518"
+                x="-1022.333"
+                y="-148.20619"
               >
                 <tspan
                   id="arrow_node4_north_incoming_number_tspan"
-                  x="141.44441"
-                  y="557.33826"
+                  x="134.69431"
+                  y="639.68726"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -2659,13 +2647,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9644;
                 `"
-                x="-1015.1211"
-                y="-203.7348"
+                x="-1021.89"
+                y="-116.99019"
               >
                 <tspan
                   id="arrows_node4_north_sum_tspan"
-                  x="142.33362"
-                  y="584.45007"
+                  x="135.56476"
+                  y="671.1947"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -2869,7 +2857,7 @@
             <text
               id="node5_sum_text"
               xml:space="preserve"
-              transform="matrix(0.61288545,-0.61288545,0.81581313,0.81581313,0,0)"
+              transform="rotate(-45)"
               :style="`
                 font-style: normal;
                 font-variant: normal;
@@ -2890,13 +2878,13 @@
                 fill-opacity: 1;
                 stroke-width: 43.9645;
               `"
-              x="-399.63812"
-              y="79.779076"
+              x="-494.45148"
+              y="216.14178"
             >
               <tspan
                 id="node5_sum_tspan"
-                x="757.8175"
-                y="867.96423"
+                x="663.00421"
+                y="1004.327"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -2937,7 +2925,7 @@
                 v-if="arrowNodeFiveNorthWestIncomingAvailable"
                 id="arrow_node5_north_west_incoming_number_text"
                 xml:space="preserve"
-                transform="matrix(0.61311236,-0.61311236,0.8155112,0.8155112,0,0)"
+                transform="rotate(-45)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -2958,13 +2946,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-399.20233"
-                y="-7.9779282"
+                x="-493.82706"
+                y="114.43393"
               >
                 <tspan
                   id="arrow_node5_north_west_incoming_number_tspan"
-                  x="757.82507"
-                  y="779.91565"
+                  x="663.20032"
+                  y="902.32751"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -2986,7 +2974,7 @@
                 v-if="arrowNodeFiveNorthWestOutgoingAvailable"
                 id="arrow_node5_north_west_outgoing_number_text"
                 xml:space="preserve"
-                transform="matrix(0.61311236,-0.61311236,0.8155112,0.8155112,0,0)"
+                transform="rotate(-45)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -3007,13 +2995,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-399.20517"
-                y="20.852219"
+                x="-493.82944"
+                y="147.68399"
               >
                 <tspan
                   id="arrow_node5_north_west_outgoing_number_tspan"
-                  x="757.82214"
-                  y="808.74573"
+                  x="663.19788"
+                  y="935.57745"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -3038,7 +3026,7 @@
                 "
                 id="arrows_node5_north_west_sum_text"
                 xml:space="preserve"
-                transform="matrix(0.61288598,-0.61288598,0.81581243,0.81581243,0,0)"
+                transform="rotate(-45)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -3059,13 +3047,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9644;
                 `"
-                x="-399.64072"
-                y="47.580051"
+                x="-494.453"
+                y="178.99188"
               >
                 <tspan
                   id="arrows_node5_north_west_sum_tspan"
-                  x="757.81403"
-                  y="835.76489"
+                  x="663.00171"
+                  y="967.17664"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -3114,7 +3102,7 @@
                 v-if="arrowNodeFiveSouthEastIncomingAvailable"
                 id="arrow_node5_south_east_incoming_number_text"
                 xml:space="preserve"
-                transform="matrix(0.61311236,-0.61311236,0.8155112,0.8155112,0,0)"
+                transform="rotate(-45)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -3135,13 +3123,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-399.20517"
-                y="136.17249"
+                x="-493.82947"
+                y="280.68359"
               >
                 <tspan
                   id="arrow_node5_south_east_incoming_number_tspan"
-                  x="757.82214"
-                  y="924.06604"
+                  x="663.19788"
+                  y="1068.5773"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -3163,7 +3151,7 @@
                 v-if="arrowNodeFiveSouthEastOutgoingAvailable"
                 id="arrow_node5_south_east_outgoing_number_text"
                 xml:space="preserve"
-                transform="matrix(0.61311236,-0.61311236,0.8155112,0.8155112,0,0)"
+                transform="rotate(-45)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -3184,13 +3172,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-399.2023"
-                y="165.00262"
+                x="-493.827"
+                y="313.93362"
               >
                 <tspan
                   id="arrow_node5_south_east_outgoing_number_tspan"
-                  x="757.82501"
-                  y="952.89612"
+                  x="663.20032"
+                  y="1101.8271"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -3215,7 +3203,7 @@
                 "
                 id="arrows_node5_south_east_sum_text"
                 xml:space="preserve"
-                transform="matrix(0.61288598,-0.61288598,0.81581243,0.81581243,0,0)"
+                transform="rotate(-45)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -3236,13 +3224,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9644;
                 `"
-                x="-399.63785"
-                y="191.67722"
+                x="-494.45044"
+                y="345.24139"
               >
                 <tspan
                   id="arrows_node5_south_east_sum_tspan"
-                  x="757.81683"
-                  y="979.86206"
+                  x="663.00421"
+                  y="1133.4263"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -3447,7 +3435,7 @@
             <text
               id="node6_sum_text"
               xml:space="preserve"
-              transform="matrix(0.61288545,0.61288545,-0.81581313,0.81581313,0,0)"
+              transform="rotate(45)"
               :style="`
                 font-style: normal;
                 font-variant: normal;
@@ -3468,13 +3456,13 @@
                 fill-opacity: 1;
                 stroke-width: 43.9645;
               `"
-              x="742.49854"
-              y="-778.25079"
+              x="499.97598"
+              y="-778.27582"
             >
               <tspan
                 id="node6_sum_tspan"
-                x="1899.9543"
-                y="9.9343462"
+                x="1657.4318"
+                y="9.9092941"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -3515,7 +3503,7 @@
                 v-if="arrowNodeSixNorthEastIncomingAvailable"
                 id="arrow_node6_north_east_incoming_number_text"
                 xml:space="preserve"
-                transform="matrix(0.61311236,0.61311236,-0.8155112,0.8155112,0,0)"
+                transform="rotate(45)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -3536,13 +3524,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="741.38873"
-                y="-866.33527"
+                x="499.54016"
+                y="-879.90857"
               >
                 <tspan
                   id="arrow_node6_north_east_incoming_number_tspan"
-                  x="1898.416"
-                  y="-78.441635"
+                  x="1656.5675"
+                  y="-92.014687"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -3564,7 +3552,7 @@
                 v-if="arrowNodeSixNorthEastOutgoingAvailable"
                 id="arrow_node6_north_east_outgoing_number_text"
                 xml:space="preserve"
-                transform="matrix(0.61311236,0.61311236,-0.8155112,0.8155112,0,0)"
+                transform="rotate(45)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -3585,13 +3573,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="741.38599"
-                y="-837.50513"
+                x="499.53778"
+                y="-846.65826"
               >
                 <tspan
                   id="arrow_node6_north_east_outgoing_number_tspan"
-                  x="1898.4132"
-                  y="-49.611588"
+                  x="1656.5651"
+                  y="-58.764801"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -3616,7 +3604,7 @@
                 "
                 id="arrows_node6_north_east_sum_text"
                 xml:space="preserve"
-                transform="matrix(0.61288598,0.61288598,-0.81581243,0.81581243,0,0)"
+                transform="rotate(45)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -3637,13 +3625,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9644;
                 `"
-                x="742.49811"
-                y="-810.4613"
+                x="499.97711"
+                y="-815.43823"
               >
                 <tspan
                   id="arrows_node6_north_east_sum_tspan"
-                  x="1899.9528"
-                  y="-22.276493"
+                  x="1657.4318"
+                  y="-27.253418"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -3692,7 +3680,7 @@
                 v-if="arrowNodeSixSouthWestIncomingAvailable"
                 id="arrow_node6_south_west_incoming_number_text"
                 xml:space="preserve"
-                transform="matrix(0.61311236,0.61311236,-0.8155112,0.8155112,0,0)"
+                transform="rotate(45)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -3713,13 +3701,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="741.38593"
-                y="-722.18481"
+                x="499.53769"
+                y="-713.65863"
               >
                 <tspan
                   id="arrow_node6_south_west_incoming_number_tspan"
-                  x="1898.4132"
-                  y="65.708748"
+                  x="1656.5651"
+                  y="74.234932"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -3741,7 +3729,7 @@
                 v-if="arrowNodeSixSouthWestOutgoingAvailable"
                 id="arrow_node6_south_west_outgoing_number_text"
                 xml:space="preserve"
-                transform="matrix(0.61311236,0.61311236,-0.8155112,0.8155112,0,0)"
+                transform="rotate(45)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -3762,13 +3750,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="741.38873"
-                y="-693.35468"
+                x="499.54025"
+                y="-680.40863"
               >
                 <tspan
                   id="arrow_node6_south_west_outgoing_number_tspan"
-                  x="1898.416"
-                  y="94.53878"
+                  x="1656.5675"
+                  y="107.48486"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -3793,7 +3781,7 @@
                 "
                 id="arrows_node6_south_west_sum_text"
                 xml:space="preserve"
-                transform="matrix(0.61288598,0.61288598,-0.81581243,0.81581243,0,0)"
+                transform="rotate(45)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -3814,13 +3802,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9644;
                 `"
-                x="742.49805"
-                y="-666.362"
+                x="499.97708"
+                y="-649.18616"
               >
                 <tspan
                   id="arrows_node6_south_west_sum_tspan"
-                  x="1899.9528"
-                  y="121.82278"
+                  x="1657.4318"
+                  y="138.99867"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -4057,7 +4045,7 @@
             <text
               id="node7_sum_text"
               xml:space="preserve"
-              transform="matrix(0.61288545,-0.61288545,0.81581313,0.81581313,0,0)"
+              transform="rotate(-45)"
               :style="`
                 font-style: normal;
                 font-variant: normal;
@@ -4078,13 +4066,13 @@
                 fill-opacity: 1;
                 stroke-width: 43.9645;
               `"
-              x="-1822.7341"
-              y="79.781219"
+              x="-1727.9211"
+              y="216.14433"
             >
               <tspan
                 id="node7_sum_tspan"
-                x="-665.27838"
-                y="867.96637"
+                x="-570.46545"
+                y="1004.3294"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -4125,7 +4113,7 @@
                 v-if="arrowNodeSevenSouthEastOutgoingAvailable"
                 id="arrow_node7_south_east_outgoing_number_text"
                 xml:space="preserve"
-                transform="matrix(0.61311236,-0.61311236,0.8155112,0.8155112,0,0)"
+                transform="rotate(-45)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -4146,13 +4134,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-1821.7715"
-                y="136.17253"
+                x="-1727.2966"
+                y="280.68369"
               >
                 <tspan
                   id="arrow_node7_south_east_outgoing_number_tspan"
-                  x="-664.74414"
-                  y="924.06604"
+                  x="-570.26935"
+                  y="1068.5771"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -4174,7 +4162,7 @@
                 v-if="arrowNodeSevenSouthEastIncomingAvailable"
                 id="arrow_node7_south_east_incoming_number_text"
                 xml:space="preserve"
-                transform="matrix(0.61311236,-0.61311236,0.8155112,0.8155112,0,0)"
+                transform="rotate(-45)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -4195,13 +4183,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-1821.7743"
-                y="165.00264"
+                x="-1727.2992"
+                y="313.93372"
               >
                 <tspan
                   id="arrow_node7_south_east_incoming_number_tspan"
-                  x="-664.74701"
-                  y="952.89606"
+                  x="-570.27179"
+                  y="1101.8271"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -4226,7 +4214,7 @@
                 "
                 id="arrows_node7_south_east_sum_text"
                 xml:space="preserve"
-                transform="matrix(0.61288598,-0.61288598,0.81581243,0.81581243,0,0)"
+                transform="rotate(-45)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -4247,13 +4235,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9644;
                 `"
-                x="-1822.7355"
-                y="191.67723"
+                x="-1727.9227"
+                y="345.24146"
               >
                 <tspan
                   id="arrows_node7_south_east_sum_tspan"
-                  x="-665.28058"
-                  y="979.86206"
+                  x="-570.4679"
+                  y="1133.4263"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -4302,7 +4290,7 @@
                 v-if="arrowNodeSevenNorthWestOutgoingAvailable"
                 id="arrow_node7_north_west_outgoing_number_text"
                 xml:space="preserve"
-                transform="matrix(0.61311236,-0.61311236,0.8155112,0.8155112,0,0)"
+                transform="rotate(-45)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -4323,13 +4311,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-1821.7744"
-                y="-7.9778929"
+                x="-1727.2993"
+                y="114.43401"
               >
                 <tspan
                   id="arrow_node7_north_west_outgoing_number_tspan"
-                  x="-664.74695"
-                  y="779.91565"
+                  x="-570.27179"
+                  y="902.32758"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -4351,7 +4339,7 @@
                 v-if="arrowNodeSevenNorthWestIncomingAvailable"
                 id="arrow_node7_north_west_incoming_number_text"
                 xml:space="preserve"
-                transform="matrix(0.61311236,-0.61311236,0.8155112,0.8155112,0,0)"
+                transform="rotate(-45)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -4372,13 +4360,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-1821.7715"
-                y="20.852285"
+                x="-1727.2968"
+                y="147.68407"
               >
                 <tspan
                   id="arrow_node7_north_west_incoming_number_tspan"
-                  x="-664.74414"
-                  y="808.74573"
+                  x="-570.26935"
+                  y="935.57745"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -4403,7 +4391,7 @@
                 "
                 id="arrows_node7_north_west_sum_text"
                 xml:space="preserve"
-                transform="matrix(0.61288598,-0.61288598,0.81581243,0.81581243,0,0)"
+                transform="rotate(-45)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -4424,13 +4412,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9644;
                 `"
-                x="-1822.7325"
-                y="47.580002"
+                x="-1727.9203"
+                y="178.99174"
               >
                 <tspan
                   id="arrows_node7_north_west_sum_tspan"
-                  x="-665.27777"
-                  y="835.76489"
+                  x="-570.46545"
+                  y="967.17664"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -4667,6 +4655,7 @@
             <text
               id="node8_sum_text"
               xml:space="preserve"
+              transform="rotate(45)"
               :style="`
                 font-style: normal;
                 font-variant: normal;
@@ -4687,13 +4676,13 @@
                 fill-opacity: 1;
                 stroke-width: 43.9644;
               `"
-              x="-680.59656"
-              y="-778.25226"
+              x="-733.49255"
+              y="-778.27759"
             >
               <tspan
                 id="node8_sum_tspan"
-                x="476.85812"
-                y="9.9321899"
+                x="423.96216"
+                y="9.9067898"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -4734,7 +4723,7 @@
                 v-if="arrowNodeEightSouthWestOutgoingAvailable"
                 id="arrow_node8_south_west_outgoing_number_text"
                 xml:space="preserve"
-                transform="matrix(0.61311236,0.61311236,-0.8155112,0.8155112,0,0)"
+                transform="rotate(45)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -4755,13 +4744,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-681.18036"
-                y="-722.18488"
+                x="-733.92938"
+                y="-713.65863"
               >
                 <tspan
                   id="arrow_node8_south_west_outgoing_number_tspan"
-                  x="475.84692"
-                  y="65.708733"
+                  x="423.09784"
+                  y="74.234932"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -4783,7 +4772,7 @@
                 v-if="arrowNodeEightSouthWestIncomingAvailable"
                 id="arrow_node8_south_west_incoming_number_text"
                 xml:space="preserve"
-                transform="matrix(0.61311236,0.61311236,-0.8155112,0.8155112,0,0)"
+                transform="rotate(45)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -4804,13 +4793,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-681.18329"
-                y="-693.35461"
+                x="-733.93195"
+                y="-680.40857"
               >
                 <tspan
                   id="arrow_node8_south_west_incoming_number_tspan"
-                  x="475.84406"
-                  y="94.538795"
+                  x="423.0954"
+                  y="107.48485"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -4835,7 +4824,7 @@
                 "
                 id="arrows_node8_south_west_sum_text"
                 xml:space="preserve"
-                transform="matrix(0.61288598,0.61288598,-0.81581243,0.81581243,0,0)"
+                transform="rotate(45)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -4856,13 +4845,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9644;
                 `"
-                x="-680.59656"
-                y="-666.3642"
+                x="-733.49261"
+                y="-649.18854"
               >
                 <tspan
                   id="arrows_node8_south_west_sum_tspan"
-                  x="476.85815"
-                  y="121.82064"
+                  x="423.96213"
+                  y="138.99622"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -4911,7 +4900,7 @@
                 v-if="arrowNodeEightNorthEastOutgoingAvailable"
                 id="arrow_node8_north_east_outgoing_number_text"
                 xml:space="preserve"
-                transform="matrix(0.61311236,0.61311236,-0.8155112,0.8155112,0,0)"
+                transform="rotate(45)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -4932,13 +4921,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-681.18323"
-                y="-866.33521"
+                x="-733.93188"
+                y="-879.90833"
               >
                 <tspan
                   id="arrow_node8_north_east_outgoing_number_tspan"
-                  x="475.84406"
-                  y="-78.441643"
+                  x="423.0954"
+                  y="-92.014717"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -4960,7 +4949,7 @@
                 v-if="arrowNodeEightNorthEastIncomingAvailable"
                 id="arrow_node8_north_east_incoming_number_text"
                 xml:space="preserve"
-                transform="matrix(0.61311236,0.61311236,-0.8155112,0.8155112,0,0)"
+                transform="rotate(45)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -4981,13 +4970,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-681.18036"
-                y="-837.505"
+                x="-733.92938"
+                y="-846.6582"
               >
                 <tspan
                   id="arrow_node8_north_east_incoming_number_tspan"
-                  x="475.84692"
-                  y="-49.611568"
+                  x="423.09787"
+                  y="-58.764786"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -5012,7 +5001,7 @@
                 "
                 id="arrows_node8_north_east_sum_text"
                 xml:space="preserve"
-                transform="matrix(0.61288598,0.61288598,-0.81581243,0.81581243,0,0)"
+                transform="rotate(45)"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -5033,13 +5022,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9644;
                 `"
-                x="-680.59656"
-                y="-810.45923"
+                x="-733.49261"
+                y="-815.43579"
               >
                 <tspan
                   id="arrows_node8_north_east_sum_tspan"
-                  x="476.85815"
-                  y="-22.274359"
+                  x="423.96216"
+                  y="-27.250959"
                   :style="`
                     font-style: normal;
                     font-variant: normal;

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanFjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanFjsSvg.vue
@@ -727,7 +727,7 @@
                 "
                 id="arrows_node1_west_sum_line"
                 style="fill: #000000; fill-opacity: 1; stroke-width: 29.8746"
-                d="m 645.75,142.03 v -98 h 2.45 v 98 z"
+                d="m 644.2975,142.03 v -98 h 2.45 v 98 z"
               />
             </g>
             <g id="arrows_node1_east">
@@ -904,7 +904,7 @@
                 "
                 id="arrows_node1_east_sum_line"
                 style="fill: #000000; fill-opacity: 1; stroke-width: 29.8746"
-                d="m 811.99999,142.03 v -98 h 2.45 v 98 z"
+                d="m 810.54749,142.03 v -98 h 2.45 v 98 z"
               />
             </g>
           </g>
@@ -1294,7 +1294,7 @@
                 "
                 id="arrows_node2_north_sum_line"
                 style="fill: #000000; fill-opacity: 1; stroke-width: 29.8774"
-                d="m 1260,645.75 h 98 v 2.45 h -98 z"
+                d="m 1270.0345,644.2975 h 98 v 2.45 h -98 z"
               />
             </g>
             <g id="arrows_node2_south">
@@ -1468,7 +1468,7 @@
                 "
                 id="arrows_node2_south_sum_line"
                 style="fill: #000000; fill-opacity: 1; stroke-width: 29.8746"
-                d="m 1260,811.99999 h 98 v 2.45 h -98 z"
+                d="m 1270.0345,810.54749 h 98 v 2.45 h -98 z"
               />
             </g>
           </g>
@@ -1901,7 +1901,7 @@
                 "
                 id="arrows_node3_east_sum_line"
                 style="fill: #000000; fill-opacity: 1; stroke-width: 29.8746"
-                d="m 811.99999,1375.5 v -98 h 2.45 v 98 z"
+                d="m 810.54749,1375.5 v -98 h 2.45 v 98 z"
               />
             </g>
             <g id="arrows_node3_west">
@@ -2078,7 +2078,7 @@
                 "
                 id="arrows_node3_west_sum_line"
                 style="fill: #000000; fill-opacity: 1; stroke-width: 29.8746"
-                d="m 645.75,1375.5 v -98 h 2.45 v 98 z"
+                d="m 644.2975,1375.5 v -98 h 2.45 v 98 z"
               />
             </g>
           </g>
@@ -2504,7 +2504,7 @@
                 "
                 id="arrows_node4_south_sum_line"
                 style="fill: #000000; fill-opacity: 1; stroke-width: 29.8746"
-                d="m 24.5,811.99999 h 98 v 2.45 h -98 z"
+                d="m 36.5645,810.54749 h 98 v 2.45 h -98 z"
               />
             </g>
             <g id="arrows_node4_north">
@@ -2678,7 +2678,7 @@
                 "
                 id="arrows_node4_north_sum_line"
                 style="fill: #000000; fill-opacity: 1; stroke-width: 29.8746"
-                d="m 24.5,645.75 h 98 v 2.45 h -98 z"
+                d="m 36.5645,644.2975 h 98 v 2.45 h -98 z"
               />
             </g>
           </g>
@@ -3078,7 +3078,7 @@
                 "
                 id="arrows_node5_north_west_sum_line"
                 style="fill: #000000; fill-opacity: 1; stroke-width: 29.8746"
-                d="m 1056.1845,267.09547 69.2965,-69.29647 1.7324,1.73241 -69.2965,69.29647 z"
+                d="m 1063.5929,267.09547 69.2965,-69.29647 1.7324,1.73241 -69.2965,69.29647 z"
               />
             </g>
             <g id="arrows_node5_south_east">
@@ -3255,7 +3255,7 @@
                 "
                 id="arrows_node5_south_east_sum_line"
                 style="fill: #000000; fill-opacity: 1; stroke-width: 29.8746"
-                d="m 1173.739,384.64997 69.2965,-69.29647 1.7324,1.73241 -69.2965,69.29647 z"
+                d="m 1181.1474,384.64997 69.2965,-69.29647 1.7324,1.73241 -69.2965,69.29647 z"
               />
             </g>
           </g>
@@ -3656,7 +3656,7 @@
                 "
                 id="arrows_node6_north_east_sum_line"
                 style="fill: #000000; fill-opacity: 1; stroke-width: 29.8774"
-                d="m 1134.3394,1057.6195 69.2964,69.2965 -1.7324,1.7324 -69.2964,-69.2965 z"
+                d="m 1139.8957,1063.1758 69.2964,69.2965 -1.7324,1.7324 -69.2964,-69.2965 z"
               />
             </g>
             <g id="arrows_node6_south_west">
@@ -3833,7 +3833,7 @@
                 "
                 id="arrows_node6_south_west_sum_line"
                 style="fill: #000000; fill-opacity: 1; stroke-width: 29.8746"
-                d="m 1016.7849,1175.1775 69.2964,69.2965 -1.7324,1.7324 -69.2964,-69.2965 z"
+                d="m 1022.3412,1180.7338 69.2964,69.2965 -1.7324,1.7324 -69.2964,-69.2965 z"
               />
             </g>
           </g>
@@ -4266,7 +4266,7 @@
                 "
                 id="arrows_node7_south_east_sum_line"
                 style="fill: #000000; fill-opacity: 1; stroke-width: 29.8746"
-                d="m 301.546,1256.8464 69.29647,-69.2964 1.73241,1.7324 -69.29647,69.2964 z"
+                d="m 308.95432,1256.8464 69.29647,-69.2964 1.73241,1.7324 -69.29647,69.2964 z"
               />
             </g>
             <g id="arrows_node7_north_west">
@@ -4443,7 +4443,7 @@
                 "
                 id="arrows_node7_north_west_sum_line"
                 style="fill: #000000; fill-opacity: 1; stroke-width: 29.8746"
-                d="m 183.988,1139.2884 69.29647,-69.2964 1.73241,1.7324 -69.29647,69.2964 z"
+                d="m 191.39632,1139.2884 69.29647,-69.2964 1.73241,1.7324 -69.29647,69.2964 z"
               />
             </g>
           </g>
@@ -4876,7 +4876,7 @@
                 "
                 id="arrows_node8_south_west_sum_line"
                 style="fill: #000000; fill-opacity: 1; stroke-width: 29.8746"
-                d="m 143.15341,301.546 69.29647,69.29647 -1.73241,1.73241 -69.29647,-69.29647 z"
+                d="m 150.56173,308.95432 69.29647,69.29647 -1.73241,1.73241 -69.29647,-69.29647 z"
               />
             </g>
             <g id="arrows_node8_north_east">
@@ -5053,7 +5053,7 @@
                 "
                 id="arrows_node8_north_east_sum_line"
                 style="fill: #000000; fill-opacity: 1; stroke-width: 29.8746"
-                d="m 260.71141,183.988 69.29647,69.29647 -1.73241,1.73241 -69.29647,-69.29647 z"
+                d="m 268.11973,191.39632 69.29647,69.29647 -1.73241,1.73241 -69.29647,-69.29647 z"
               />
             </g>
           </g>

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanFjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanFjsSvg.vue
@@ -239,21 +239,21 @@
                 stroke-width: 28.2205;
                 stroke-dasharray: none;
               `"
-              x="1107.2496"
-              y="85.837341"
+              x="1107.0699"
+              y="84.662277"
             >
               <tspan
                 id="tspan21"
-                x="1107.2496"
-                y="85.837341"
+                x="1107.0699"
+                y="84.662277"
               >
                 Stadtbezirk
                 {{ zaehlstelleStore.getZaehlstelleHeader.stadtbezirkNummer }}
               </tspan>
               <tspan
                 id="tspan22"
-                x="1107.2496"
-                y="112.26053"
+                x="1107.0699"
+                y="110.83184"
               >
                 Zähldatum:
                 {{
@@ -293,13 +293,13 @@
                 stroke-width: 28.2205;
                 stroke-dasharray: none;
               `"
-              x="1107.2496"
-              y="60.337341"
+              x="1107.0699"
+              y="58.662277"
             >
               <tspan
                 id="tspan24"
-                x="1107.2496"
-                y="60.337341"
+                x="1107.0699"
+                y="58.662277"
               >
                 <tspan
                   id="tspan23"

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanFjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanFjsSvg.vue
@@ -45,13 +45,13 @@
               stroke-width: 28.2205;
               stroke-dasharray: none;
             `"
-            x="56.249691"
-            y="1310.3373"
+            x="56"
+            y="1307.6622"
           >
             <tspan
               id="tspan13"
-              x="56.249691"
-              y="1310.3373"
+              x="56"
+              y="1307.6622"
             >
               <tspan
                 id="tspan12"
@@ -90,13 +90,13 @@
                 stroke-width: 28.2205;
                 stroke-dasharray: none;
               `"
-              x="56.249691"
-              y="1257"
+              x="56"
+              y="1255.6622"
             >
               <tspan
                 id="tspan18"
-                x="56.249691"
-                y="1257"
+                x="56"
+                y="1255.6622"
               >
                 {{ zaehlzeit2 }}
               </tspan>
@@ -131,13 +131,13 @@
                 stroke-width: 28.2205;
                 stroke-dasharray: none;
               `"
-              x="56.249691"
-              y="1230.3373"
+              x="56"
+              y="1229.6622"
             >
               <tspan
                 id="tspan20"
-                x="56.249691"
-                y="1230.3373"
+                x="56"
+                y="1229.6622"
               >
                 <tspan
                   id="tspan19"

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanFjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanFjsSvg.vue
@@ -527,12 +527,12 @@
                 fill-opacity: 1;
                 stroke-width: 43.9645;
               `"
-              x="-1200.4841"
+              x="-1188.4197"
               y="-79.837906"
             >
               <tspan
                 id="node1_sum_tspan"
-                x="-43.028492"
+                x="-30.963991"
                 y="708.34723"
                 :style="`
                   font-style: normal;
@@ -595,12 +595,12 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-1199.7682"
+                x="-1188.8622"
                 y="-181.45634"
               >
                 <tspan
                   id="arrow_node1_west_incoming_number_tspan"
-                  x="-42.740871"
+                  x="-31.834871"
                   y="606.43726"
                   :style="`
                     font-style: normal;
@@ -644,12 +644,12 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-1199.7682"
+                x="-1188.8622"
                 y="-148.20622"
               >
                 <tspan
                   id="arrow_node1_west_outgoing_number_tspan"
-                  x="-42.740871"
+                  x="-31.834871"
                   y="639.68726"
                   :style="`
                     font-style: normal;
@@ -696,12 +696,12 @@
                   fill-opacity: 1;
                   stroke-width: 43.9644;
                 `"
-                x="-1200.4833"
+                x="-1188.4188"
                 y="-116.99011"
               >
                 <tspan
                   id="arrows_node1_west_sum_tspan"
-                  x="-43.028492"
+                  x="-30.963991"
                   y="671.1947"
                   :style="`
                     font-style: normal;
@@ -727,7 +727,7 @@
                 "
                 id="arrows_node1_west_sum_line"
                 style="fill: #000000; fill-opacity: 1; stroke-width: 29.8746"
-                d="m 644.2975,142.03 v -98 h 2.45 v 98 z"
+                d="m 644.2975,129.9655 v -98 h 2.45 v 98 z"
               />
             </g>
             <g id="arrows_node1_east">
@@ -772,12 +772,12 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-1199.7682"
+                x="-1188.8622"
                 y="-15.206282"
               >
                 <tspan
                   id="arrow_node1_east_incoming_number_tspan"
-                  x="-42.740871"
+                  x="-31.834871"
                   y="772.68726"
                   :style="`
                     font-style: normal;
@@ -821,12 +821,12 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-1199.7682"
+                x="-1188.8622"
                 y="18.043777"
               >
                 <tspan
                   id="arrow_node1_east_outgoing_number_tspan"
-                  x="-42.740871"
+                  x="-31.834871"
                   y="805.93726"
                   :style="`
                     font-style: normal;
@@ -873,12 +873,12 @@
                   fill-opacity: 1;
                   stroke-width: 43.9644;
                 `"
-                x="-1200.4833"
+                x="-1188.4188"
                 y="49.25988"
               >
                 <tspan
                   id="arrows_node1_east_sum_tspan"
-                  x="-43.028492"
+                  x="-30.963991"
                   y="837.4447"
                   :style="`
                     font-style: normal;
@@ -904,7 +904,7 @@
                 "
                 id="arrows_node1_east_sum_line"
                 style="fill: #000000; fill-opacity: 1; stroke-width: 29.8746"
-                d="m 810.54749,142.03 v -98 h 2.45 v 98 z"
+                d="m 810.54749,129.9655 v -98 h 2.45 v 98 z"
               />
             </g>
           </g>
@@ -2307,11 +2307,11 @@
                 fill-opacity: 1;
                 stroke-width: 43.9644;
               `"
-              x="-1021.89"
+              x="-1033.9545"
               y="-79.830223"
             >
               <tspan
-                x="135.56476"
+                x="123.50026"
                 y="708.35419"
                 id="node4_sum_tspan"
                 :style="`
@@ -2374,12 +2374,12 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-1022.333"
+                x="-1033.239"
                 y="-15.206355"
               >
                 <tspan
                   id="arrow_node4_south_outgoing_number_tspan"
-                  x="134.69431"
+                  x="123.78831"
                   y="772.68726"
                   :style="`
                     font-style: normal;
@@ -2422,12 +2422,12 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-1022.333"
+                x="-1033.239"
                 y="18.043804"
               >
                 <tspan
                   id="arrow_node4_south_incoming_number_tspan"
-                  x="134.69431"
+                  x="123.78831"
                   y="805.93726"
                   :style="`
                     font-style: normal;
@@ -2473,12 +2473,12 @@
                   fill-opacity: 1;
                   stroke-width: 43.9644;
                 `"
-                x="-1021.89"
+                x="-1033.9545"
                 y="49.259884"
               >
                 <tspan
                   id="arrows_node4_south_sum_tspan"
-                  x="135.56476"
+                  x="123.50026"
                   y="837.4447"
                   :style="`
                     font-style: normal;
@@ -2504,7 +2504,7 @@
                 "
                 id="arrows_node4_south_sum_line"
                 style="fill: #000000; fill-opacity: 1; stroke-width: 29.8746"
-                d="m 36.5645,810.54749 h 98 v 2.45 h -98 z"
+                d="m 24.5,810.54749 h 98 v 2.45 h -98 z"
               />
             </g>
             <g id="arrows_node4_north">
@@ -2548,12 +2548,12 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-1022.333"
+                x="-1033.239"
                 y="-181.45634"
               >
                 <tspan
                   id="arrow_node4_north_outgoing_number_tspan"
-                  x="134.69431"
+                  x="123.78831"
                   y="606.43726"
                   :style="`
                     font-style: normal;
@@ -2596,12 +2596,12 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-1022.333"
+                x="-1033.239"
                 y="-148.20619"
               >
                 <tspan
                   id="arrow_node4_north_incoming_number_tspan"
-                  x="134.69431"
+                  x="123.78831"
                   y="639.68726"
                   :style="`
                     font-style: normal;
@@ -2647,12 +2647,12 @@
                   fill-opacity: 1;
                   stroke-width: 43.9644;
                 `"
-                x="-1021.89"
+                x="-1033.9545"
                 y="-116.99019"
               >
                 <tspan
                   id="arrows_node4_north_sum_tspan"
-                  x="135.56476"
+                  x="123.50026"
                   y="671.1947"
                   :style="`
                     font-style: normal;
@@ -2678,7 +2678,7 @@
                 "
                 id="arrows_node4_north_sum_line"
                 style="fill: #000000; fill-opacity: 1; stroke-width: 29.8746"
-                d="m 36.5645,644.2975 h 98 v 2.45 h -98 z"
+                d="m 24.5,644.2975 h 98 v 2.45 h -98 z"
               />
             </g>
           </g>
@@ -2878,13 +2878,13 @@
                 fill-opacity: 1;
                 stroke-width: 43.9645;
               `"
-              x="-494.45148"
-              y="216.14178"
+              x="-483.45068"
+              y="211.86259"
             >
               <tspan
                 id="node5_sum_tspan"
-                x="663.00421"
-                y="1004.327"
+                x="674.005"
+                y="1000.0479"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -2946,13 +2946,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-493.82706"
-                y="114.43393"
+                x="-482.82623"
+                y="110.15491"
               >
                 <tspan
                   id="arrow_node5_north_west_incoming_number_tspan"
-                  x="663.20032"
-                  y="902.32751"
+                  x="674.20111"
+                  y="898.04852"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -2995,13 +2995,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-493.82944"
-                y="147.68399"
+                x="-482.82864"
+                y="143.40495"
               >
                 <tspan
                   id="arrow_node5_north_west_outgoing_number_tspan"
-                  x="663.19788"
-                  y="935.57745"
+                  x="674.19867"
+                  y="931.2984"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -3047,13 +3047,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9644;
                 `"
-                x="-494.453"
-                y="178.99188"
+                x="-483.45218"
+                y="174.71283"
               >
                 <tspan
                   id="arrows_node5_north_west_sum_tspan"
-                  x="663.00171"
-                  y="967.17664"
+                  x="674.00256"
+                  y="962.89758"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -3078,7 +3078,7 @@
                 "
                 id="arrows_node5_north_west_sum_line"
                 style="fill: #000000; fill-opacity: 1; stroke-width: 29.8746"
-                d="m 1063.5929,267.09547 69.2965,-69.29647 1.7324,1.73241 -69.2965,69.29647 z"
+                d="m 1068.347,256.29097 69.2965,-69.29647 1.7324,1.73241 -69.2965,69.29647 z"
               />
             </g>
             <g id="arrows_node5_south_east">
@@ -3123,13 +3123,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-493.82947"
-                y="280.68359"
+                x="-482.82867"
+                y="276.40448"
               >
                 <tspan
                   id="arrow_node5_south_east_incoming_number_tspan"
-                  x="663.19788"
-                  y="1068.5773"
+                  x="674.19867"
+                  y="1064.2981"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -3172,13 +3172,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-493.827"
-                y="313.93362"
+                x="-482.82614"
+                y="309.65457"
               >
                 <tspan
                   id="arrow_node5_south_east_outgoing_number_tspan"
-                  x="663.20032"
-                  y="1101.8271"
+                  x="674.20111"
+                  y="1097.5481"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -3224,13 +3224,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9644;
                 `"
-                x="-494.45044"
-                y="345.24139"
+                x="-483.44965"
+                y="340.96234"
               >
                 <tspan
                   id="arrows_node5_south_east_sum_tspan"
-                  x="663.00421"
-                  y="1133.4263"
+                  x="674.00494"
+                  y="1129.1472"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -3255,7 +3255,7 @@
                 "
                 id="arrows_node5_south_east_sum_line"
                 style="fill: #000000; fill-opacity: 1; stroke-width: 29.8746"
-                d="m 1181.1474,384.64997 69.2965,-69.29647 1.7324,1.73241 -69.2965,69.29647 z"
+                d="m 1185.9015,373.84547 69.2965,-69.29647 1.7324,1.73241 -69.2965,69.29647 z"
               />
             </g>
           </g>
@@ -3456,13 +3456,13 @@
                 fill-opacity: 1;
                 stroke-width: 43.9645;
               `"
-              x="499.97598"
-              y="-778.27582"
+              x="506.49976"
+              y="-778.08771"
             >
               <tspan
                 id="node6_sum_tspan"
-                x="1657.4318"
-                y="9.9092941"
+                x="1663.9556"
+                y="10.097366"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -3524,13 +3524,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="499.54016"
-                y="-879.90857"
+                x="506.0639"
+                y="-879.72052"
               >
                 <tspan
                   id="arrow_node6_north_east_incoming_number_tspan"
-                  x="1656.5675"
-                  y="-92.014687"
+                  x="1663.0913"
+                  y="-91.826622"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -3573,13 +3573,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="499.53778"
-                y="-846.65826"
+                x="506.06149"
+                y="-846.47015"
               >
                 <tspan
                   id="arrow_node6_north_east_outgoing_number_tspan"
-                  x="1656.5651"
-                  y="-58.764801"
+                  x="1663.0887"
+                  y="-58.576717"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -3625,13 +3625,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9644;
                 `"
-                x="499.97711"
-                y="-815.43823"
+                x="506.50089"
+                y="-815.25012"
               >
                 <tspan
                   id="arrows_node6_north_east_sum_tspan"
-                  x="1657.4318"
-                  y="-27.253418"
+                  x="1663.9556"
+                  y="-27.06534"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -3656,7 +3656,7 @@
                 "
                 id="arrows_node6_north_east_sum_line"
                 style="fill: #000000; fill-opacity: 1; stroke-width: 29.8774"
-                d="m 1139.8957,1063.1758 69.2964,69.2965 -1.7324,1.7324 -69.2964,-69.2965 z"
+                d="m 1144.3774,1067.9235 69.2964,69.2965 -1.7324,1.7324 -69.2964,-69.2965 z"
               />
             </g>
             <g id="arrows_node6_south_west">
@@ -3701,13 +3701,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="499.53769"
-                y="-713.65863"
+                x="506.0614"
+                y="-713.47058"
               >
                 <tspan
                   id="arrow_node6_south_west_incoming_number_tspan"
-                  x="1656.5651"
-                  y="74.234932"
+                  x="1663.0887"
+                  y="74.422997"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -3750,13 +3750,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="499.54025"
-                y="-680.40863"
+                x="506.06403"
+                y="-680.22058"
               >
                 <tspan
                   id="arrow_node6_south_west_outgoing_number_tspan"
-                  x="1656.5675"
-                  y="107.48486"
+                  x="1663.0913"
+                  y="107.67294"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -3802,13 +3802,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9644;
                 `"
-                x="499.97708"
-                y="-649.18616"
+                x="506.50089"
+                y="-648.99805"
               >
                 <tspan
                   id="arrows_node6_south_west_sum_tspan"
-                  x="1657.4318"
-                  y="138.99867"
+                  x="1663.9556"
+                  y="139.18677"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -3833,7 +3833,7 @@
                 "
                 id="arrows_node6_south_west_sum_line"
                 style="fill: #000000; fill-opacity: 1; stroke-width: 29.8746"
-                d="m 1022.3412,1180.7338 69.2964,69.2965 -1.7324,1.7324 -69.2964,-69.2965 z"
+                d="m 1026.8229,1185.4815 69.2964,69.2965 -1.7324,1.7324 -69.2964,-69.2965 z"
               />
             </g>
           </g>
@@ -4066,13 +4066,13 @@
                 fill-opacity: 1;
                 stroke-width: 43.9645;
               `"
-              x="-1727.9211"
-              y="216.14433"
+              x="-1738.3558"
+              y="210.94797"
             >
               <tspan
                 id="node7_sum_tspan"
-                x="-570.46545"
-                y="1004.3294"
+                x="-580.90033"
+                y="999.13306"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -4134,13 +4134,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-1727.2966"
-                y="280.68369"
+                x="-1738.4728"
+                y="276.22891"
               >
                 <tspan
                   id="arrow_node7_south_east_outgoing_number_tspan"
-                  x="-570.26935"
-                  y="1068.5771"
+                  x="-581.4458"
+                  y="1064.1224"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -4183,13 +4183,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-1727.2992"
-                y="313.93372"
+                x="-1738.4755"
+                y="309.47891"
               >
                 <tspan
                   id="arrow_node7_south_east_incoming_number_tspan"
-                  x="-570.27179"
-                  y="1101.8271"
+                  x="-581.4483"
+                  y="1097.3723"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -4235,13 +4235,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9644;
                 `"
-                x="-1727.9227"
-                y="345.24146"
+                x="-1739.099"
+                y="340.78668"
               >
                 <tspan
                   id="arrows_node7_south_east_sum_tspan"
-                  x="-570.4679"
-                  y="1133.4263"
+                  x="-581.64447"
+                  y="1128.9714"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -4266,7 +4266,7 @@
                 "
                 id="arrows_node7_south_east_sum_line"
                 style="fill: #000000; fill-opacity: 1; stroke-width: 29.8746"
-                d="m 308.95432,1256.8464 69.29647,-69.2964 1.73241,1.7324 -69.29647,69.2964 z"
+                d="m 297.899,1261.5994 69.29647,-69.2964 1.73241,1.7324 -69.29647,69.2964 z"
               />
             </g>
             <g id="arrows_node7_north_west">
@@ -4311,13 +4311,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-1727.2993"
-                y="114.43401"
+                x="-1738.4756"
+                y="109.97922"
               >
                 <tspan
                   id="arrow_node7_north_west_outgoing_number_tspan"
-                  x="-570.27179"
-                  y="902.32758"
+                  x="-581.4483"
+                  y="897.87274"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -4360,13 +4360,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-1727.2968"
-                y="147.68407"
+                x="-1738.473"
+                y="143.22932"
               >
                 <tspan
                   id="arrow_node7_north_west_incoming_number_tspan"
-                  x="-570.26935"
-                  y="935.57745"
+                  x="-581.44586"
+                  y="931.12274"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -4412,13 +4412,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9644;
                 `"
-                x="-1727.9203"
-                y="178.99174"
+                x="-1739.0966"
+                y="174.53697"
               >
                 <tspan
                   id="arrows_node7_north_west_sum_tspan"
-                  x="-570.46545"
-                  y="967.17664"
+                  x="-581.64203"
+                  y="962.72186"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -4443,7 +4443,7 @@
                 "
                 id="arrows_node7_north_west_sum_line"
                 style="fill: #000000; fill-opacity: 1; stroke-width: 29.8746"
-                d="m 191.39632,1139.2884 69.29647,-69.2964 1.73241,1.7324 -69.29647,69.2964 z"
+                d="m 180.341,1144.0414 69.29647,-69.2964 1.73241,1.7324 -69.29647,69.2964 z"
               />
             </g>
           </g>
@@ -4676,13 +4676,13 @@
                 fill-opacity: 1;
                 stroke-width: 43.9644;
               `"
-              x="-733.49255"
-              y="-778.27759"
+              x="-749.14612"
+              y="-778.26025"
             >
               <tspan
                 id="node8_sum_tspan"
-                x="423.96216"
-                y="9.9067898"
+                x="408.30856"
+                y="9.9241133"
                 :style="`
                   font-style: normal;
                   font-variant: normal;
@@ -4744,13 +4744,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-733.92938"
-                y="-713.65863"
+                x="-749.58295"
+                y="-713.6413"
               >
                 <tspan
                   id="arrow_node8_south_west_outgoing_number_tspan"
-                  x="423.09784"
-                  y="74.234932"
+                  x="407.44427"
+                  y="74.252251"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -4793,13 +4793,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-733.93195"
-                y="-680.40857"
+                x="-749.58551"
+                y="-680.39124"
               >
                 <tspan
                   id="arrow_node8_south_west_incoming_number_tspan"
-                  x="423.0954"
-                  y="107.48485"
+                  x="407.4418"
+                  y="107.50217"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -4845,13 +4845,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9644;
                 `"
-                x="-733.49261"
-                y="-649.18854"
+                x="-749.14618"
+                y="-649.1712"
               >
                 <tspan
                   id="arrows_node8_south_west_sum_tspan"
-                  x="423.96213"
-                  y="138.99622"
+                  x="408.30856"
+                  y="139.01353"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -4876,7 +4876,7 @@
                 "
                 id="arrows_node8_south_west_sum_line"
                 style="fill: #000000; fill-opacity: 1; stroke-width: 29.8746"
-                d="m 150.56173,308.95432 69.29647,69.29647 -1.73241,1.73241 -69.29647,-69.29647 z"
+                d="m 139.47841,297.8955 69.29647,69.29647 -1.73241,1.73241 -69.29647,-69.29647 z"
               />
             </g>
             <g id="arrows_node8_north_east">
@@ -4921,13 +4921,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-733.93188"
-                y="-879.90833"
+                x="-749.58545"
+                y="-879.89099"
               >
                 <tspan
                   id="arrow_node8_north_east_outgoing_number_tspan"
-                  x="423.0954"
-                  y="-92.014717"
+                  x="407.4418"
+                  y="-91.997398"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -4970,13 +4970,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="-733.92938"
-                y="-846.6582"
+                x="-749.58295"
+                y="-846.64087"
               >
                 <tspan
                   id="arrow_node8_north_east_incoming_number_tspan"
-                  x="423.09787"
-                  y="-58.764786"
+                  x="407.44427"
+                  y="-58.747467"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -5022,13 +5022,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9644;
                 `"
-                x="-733.49261"
-                y="-815.43579"
+                x="-749.14618"
+                y="-815.41846"
               >
                 <tspan
                   id="arrows_node8_north_east_sum_tspan"
-                  x="423.96216"
-                  y="-27.250959"
+                  x="408.30856"
+                  y="-27.233639"
                   :style="`
                     font-style: normal;
                     font-variant: normal;
@@ -5053,7 +5053,7 @@
                 "
                 id="arrows_node8_north_east_sum_line"
                 style="fill: #000000; fill-opacity: 1; stroke-width: 29.8746"
-                d="m 268.11973,191.39632 69.29647,69.29647 -1.73241,1.73241 -69.29647,-69.29647 z"
+                d="m 257.03641,180.3375 69.29647,69.29647 -1.73241,1.73241 -69.29647,-69.29647 z"
               />
             </g>
           </g>

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
@@ -568,12 +568,12 @@
                   stroke-dasharray: none;
                 `"
                 id="zaehlstelle1-multirow"
-                x="1107.2496"
-                y="60.337341"
+                x="1107.0699"
+                y="58.662277"
               >
                 <tspan
-                  x="1107.2496"
-                  y="60.337341"
+                  x="1107.0699"
+                  y="58.662277"
                   id="tspan16"
                 >
                   Zählstelle
@@ -611,20 +611,20 @@
                   stroke-dasharray: none;
                 `"
                 id="zaehlstelle2-multirow"
-                x="1107.2496"
-                y="85.837341"
+                x="1107.0699"
+                y="84.662277"
               >
                 <tspan
-                  x="1107.2496"
-                  y="85.837341"
+                  x="1107.0699"
+                  y="84.662277"
                   id="tspan17"
                 >
                   Stadtbezirk
                   {{ zaehlstelleStore.getZaehlstelleHeader.stadtbezirkNummer }}
                 </tspan>
                 <tspan
-                  x="1107.2496"
-                  y="112.26053"
+                  x="1107.0699"
+                  y="110.83184"
                   id="tspan18"
                 >
                   Zähldatum:

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
@@ -775,26 +775,26 @@
               :style="`
                 fill: none;
                 stroke: ${BelastungsplanConstants.legendColor};
-                stroke-width: 1.99499999;
+                stroke-width: 2;
                 stroke-linecap: square;
                 stroke-miterlimit: 2.5;
                 stroke-dasharray: none;
                 stroke-opacity: 1;
               `"
-              d="m 1316.5243,1294.7302 -124.9982,-0.2134 124.9982,-19.8383 z"
+              d="M 1190.6,1295 H 1316 v -20 z"
               id="massstab-path1"
             />
             <path
               :style="`
                 fill: #000000;
                 stroke: ${BelastungsplanConstants.legendColor};
-                stroke-width: 1.50489;
+                stroke-width: 2;
                 stroke-linecap: square;
                 stroke-miterlimit: 2.5;
                 stroke-dasharray: none;
                 stroke-opacity: 1;
               `"
-              d="m 1252.7468,1284.8273 c 0.1805,8.9058 0.185,8.7945 0.185,8.7945 v 0"
+              d="m 1253,1295 v -10"
               id="massstab-path2"
             />
             <g
@@ -827,12 +827,12 @@
                   stroke-dasharray: none;
                 `"
                 id="massstab-size1-multirow"
-                x="1250.2496"
-                y="1315.3373"
+                x="1253"
+                y="1315"
               >
                 <tspan
-                  x="1250.2496"
-                  y="1315.3373"
+                  x="1253"
+                  y="1315"
                   id="tspan27"
                 >
                   {{ highestZaehlwertRounded / 2 }}
@@ -869,12 +869,12 @@
                   stroke-dasharray: none;
                 `"
                 id="massstab-size2-multirow"
-                x="1316.2496"
-                y="1315.3373"
+                x="1316"
+                y="1315"
               >
                 <tspan
-                  x="1316.2496"
-                  y="1315.3373"
+                  x="1316"
+                  y="1315"
                   id="tspan28"
                 >
                   {{ highestZaehlwertRounded }}

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
@@ -295,9 +295,8 @@
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 28.0866px;
-                  font-family: sans-serif-serif;
-                  -inkscape-font-specification: &quot;Arial, Normal&quot;;
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -516,7 +515,9 @@
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
-                  stroke-width: 43.9644;
+                  fill: ${BelastungsplanConstants.legendColor};
+                  fill-opacity: 1;
+                  stroke-width: 2.2868;
                 `"
               >
                 N
@@ -714,10 +715,9 @@
                   stroke-width: 28.2205;
                   stroke-dasharray: none;
                 `"
-                id="massstab-size1-multirow"
-                x="699.24969"
-                y="688.33734"
-                transform="translate(181.39362,6.9760325e-4)"
+                id="zaehlzeit2-multirow"
+                x="56.249691"
+                y="1257"
               >
                 <tspan
                   x="56.249691"

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
@@ -670,12 +670,12 @@
                   stroke-dasharray: none;
                 `"
                 id="zaehlzeit1-multirow"
-                x="56.249691"
-                y="1230.3373"
+                x="56"
+                y="1229.6622"
               >
                 <tspan
-                  x="56.249691"
-                  y="1230.3373"
+                  x="56"
+                  y="1229.6622"
                   id="tspan23"
                 >
                   <tspan
@@ -716,12 +716,12 @@
                   stroke-dasharray: none;
                 `"
                 id="zaehlzeit2-multirow"
-                x="56.249691"
-                y="1257"
+                x="56"
+                y="1255.6622"
               >
                 <tspan
-                  x="56.249691"
-                  y="1257"
+                  x="56"
+                  y="1255.6622"
                   id="tspan24"
                 >
                   {{ zaehlzeit2 }}
@@ -753,12 +753,12 @@
                 stroke-dasharray: none;
               `"
               id="verkehrsart"
-              x="56.249691"
-              y="1310.3373"
+              x="56"
+              y="1307.6622"
             >
               <tspan
-                x="56.249691"
-                y="1310.3373"
+                x="56"
+                y="1307.6622"
                 id="tspan26"
               >
                 <tspan

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
@@ -496,12 +496,12 @@
                 text-align: start;
                 writing-mode: lr-tb;
                 direction: ltr;
-                text-anchor: start;
+                text-anchor: middle;
                 fill: ${BelastungsplanConstants.legendColor};
-                stroke-width: 2.2868;
+                stroke-width: 2;
               `"
-              x="100.26942"
-              y="84.035934"
+              x="107.33477"
+              y="83.332977"
             >
               <tspan
                 :style="`
@@ -517,25 +517,25 @@
                   font-variant-east-asian: normal;
                   fill: ${BelastungsplanConstants.legendColor};
                   fill-opacity: 1;
-                  stroke-width: 2.2868;
+                  stroke-width: 2;
                 `"
               >
                 N
               </tspan>
             </text>
             <path
-              style="
+              :style="`
                 fill: none;
                 fill-opacity: 1;
-                stroke: #666666;
-                stroke-width: 1.99499999;
+                stroke: ${BelastungsplanConstants.legendColor};
+                stroke-width: 2;
                 stroke-linecap: butt;
                 stroke-miterlimit: 2.5;
                 stroke-dasharray: none;
                 stroke-opacity: 1;
-              "
+              `"
               id="compass2"
-              d="m 107.4337,29.984176 13.9217,63.312817 H 106.06607 93.511995 Z"
+              d="m 93.333333,93.333333 h 27.999997 l -14,-63 z"
             />
           </g>
           <g id="legend-zaehlstelle">

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanQuSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanQuSvg.vue
@@ -59,9 +59,9 @@
               <text
                 id="node1_circle_text"
                 xml:space="default"
-                style="
-                  font-size: 19.7624px;
-                  font-family: sans-serif;
+                :style="`
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
                   direction: ltr;
@@ -69,7 +69,7 @@
                   fill: #000000;
                   stroke-width: 28.22049979;
                   stroke-dasharray: none;
-                "
+                `"
                 y="622.00684"
                 x="693.53955"
               >
@@ -87,13 +87,13 @@
               v-if="streetnameNode1.length === 1"
               id="node1_strassenname_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -108,7 +108,7 @@
                 fill-opacity: 1;
                 stroke-width: 28.22049979;
                 stroke-dasharray: none;
-              "
+              `"
               transform="rotate(-90)"
               x="-671.03851"
               y="629.34802"
@@ -126,13 +126,13 @@
               v-if="streetnameNode1.length > 1"
               id="node1_strassenname_multirow1_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -147,7 +147,7 @@
                 fill-opacity: 1;
                 stroke-width: 28.22049979;
                 stroke-dasharray: none;
-              "
+              `"
               transform="rotate(-90)"
               x="-671.03851"
               y="615.34802"
@@ -165,13 +165,13 @@
               v-if="streetnameNode1.length > 1"
               id="node1_strassenname_multirow2_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -186,7 +186,7 @@
                 fill-opacity: 1;
                 stroke-width: 28.22049979;
                 stroke-dasharray: none;
-              "
+              `"
               transform="rotate(-90)"
               x="-671.03851"
               y="643.34802"
@@ -205,13 +205,13 @@
                 id="node1_sum_text"
                 xml:space="preserve"
                 transform="rotate(-90)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -225,7 +225,7 @@
                   fill-opacity: 1;
                   stroke-width: 28.2205;
                   stroke-dasharray: none;
-                "
+                `"
                 x="-1347.4354"
                 y="37.009502"
               >
@@ -233,20 +233,20 @@
                   id="node1_sum_tspan"
                   x="-189.97949"
                   y="825.1947"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: 28.097px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 28.2205;
                     stroke-dasharray: none;
-                  "
+                  `"
                 >
                   {{ sumNode1Arrows }}
                 </tspan>
@@ -412,13 +412,13 @@
               v-if="streetnameNode2.length === 1"
               id="node2_strassenname_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -433,7 +433,7 @@
                 fill-opacity: 1;
                 stroke-width: 28.2205;
                 stroke-dasharray: none;
-              "
+              `"
               x="728.96271"
               y="629.34802"
             >
@@ -468,9 +468,9 @@
               <text
                 id="node2_circle_text"
                 xml:space="default"
-                style="
-                  font-size: 19.7624px;
-                  font-family: sans-serif;
+                :style="`
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
                   direction: ltr;
@@ -478,7 +478,7 @@
                   fill: #000000;
                   stroke-width: 28.2205;
                   stroke-dasharray: none;
-                "
+                `"
                 y="707.33368"
                 x="779.30457"
               >
@@ -496,13 +496,13 @@
               v-if="streetnameNode2.length > 1"
               id="node2_strassenname_multirow2_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -517,7 +517,7 @@
                 fill-opacity: 1;
                 stroke-width: 28.2205;
                 stroke-dasharray: none;
-              "
+              `"
               x="728.96271"
               y="643.34802"
             >
@@ -534,13 +534,13 @@
               v-if="streetnameNode2.length > 1"
               id="node2_strassenname_multirow1_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -555,7 +555,7 @@
                 fill-opacity: 1;
                 stroke-width: 28.2205;
                 stroke-dasharray: none;
-              "
+              `"
               x="728.96271"
               y="615.34802"
             >
@@ -577,13 +577,13 @@
                 id="node2_sum_text"
                 xml:space="preserve"
                 transform="rotate(-90)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -597,7 +597,7 @@
                   fill-opacity: 1;
                   stroke-width: 28.2205;
                   stroke-dasharray: none;
-                "
+                `"
                 x="-1347.438"
                 y="37.009502"
               >
@@ -605,20 +605,20 @@
                   id="node2_sum_tspan"
                   x="-189.98215"
                   y="825.1947"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: 28.097px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 28.2205;
                     stroke-dasharray: none;
-                  "
+                  `"
                 >
                   {{ sumNode2Arrows }}
                 </tspan>
@@ -783,13 +783,13 @@
               v-if="streetnameNode3.length === 1"
               id="node3_strassenname_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -804,27 +804,27 @@
                 fill-opacity: 1;
                 stroke-width: 28.22049979;
                 stroke-dasharray: none;
-              "
+              `"
               transform="rotate(-90)"
               x="-962.48126"
               y="705.79083"
             >
               <tspan
                 id="node3_strassenname_tspan"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 22.3767px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
                   stroke-width: 28.22049979;
                   stroke-dasharray: none;
-                "
+                `"
                 x="-962.48126"
                 y="705.79083"
               >
@@ -853,9 +853,9 @@
               <text
                 id="node3_circle_text"
                 xml:space="default"
-                style="
-                  font-size: 19.7624px;
-                  font-family: sans-serif;
+                :style="`
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
                   direction: ltr;
@@ -863,7 +863,7 @@
                   fill: #000000;
                   stroke-width: 28.22049979;
                   stroke-dasharray: none;
-                "
+                `"
                 y="792.38141"
                 x="693.75189"
               >
@@ -881,13 +881,13 @@
               v-if="streetnameNode3.length > 1"
               id="node3_strassenname_multirow2_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -902,27 +902,27 @@
                 fill-opacity: 1;
                 stroke-width: 28.22049979;
                 stroke-dasharray: none;
-              "
+              `"
               transform="rotate(-90)"
               x="-962.48126"
               y="719.79083"
             >
               <tspan
                 id="node3_strassenname_multirow2_tspan"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 22.3767px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
                   stroke-width: 28.22049979;
                   stroke-dasharray: none;
-                "
+                `"
                 x="-962.48126"
                 y="719.79083"
               >
@@ -933,13 +933,13 @@
               v-if="streetnameNode3.length > 1"
               id="node3_strassenname_multirow1_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -954,27 +954,27 @@
                 fill-opacity: 1;
                 stroke-width: 28.22049979;
                 stroke-dasharray: none;
-              "
+              `"
               transform="rotate(-90)"
               x="-962.48126"
               y="691.79083"
             >
               <tspan
                 id="node3_strassenname_multirow1_tspan"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 22.3767px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
                   stroke-width: 28.22049979;
                   stroke-dasharray: none;
-                "
+                `"
                 x="-962.48126"
                 y="691.79083"
               >
@@ -990,13 +990,13 @@
                 id="node3_sum_text"
                 xml:space="preserve"
                 transform="rotate(-90)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1010,7 +1010,7 @@
                   fill-opacity: 1;
                   stroke-width: 28.2204997;
                   stroke-dasharray: none;
-                "
+                `"
                 x="-1347.437"
                 y="37.009521"
               >
@@ -1018,20 +1018,20 @@
                   id="node3_sum_tspan"
                   x="-189.98125"
                   y="825.1947"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: 28.097px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 28.2204997;
                     stroke-dasharray: none;
-                  "
+                  `"
                 >
                   {{ sumNode3Arrows }}
                 </tspan>
@@ -1193,13 +1193,13 @@
               v-if="streetnameNode4.length === 1"
               id="node4_strassenname_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -1214,26 +1214,26 @@
                 fill-opacity: 1;
                 stroke-width: 28.22049979;
                 stroke-dasharray: none;
-              "
+              `"
               x="437.52008"
               y="705.79083"
             >
               <tspan
                 id="node4_strassenname_tspan"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 22.3767px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
                   stroke-width: 28.22049979;
                   stroke-dasharray: none;
-                "
+                `"
                 x="437.52008"
                 y="705.79083"
               >
@@ -1262,9 +1262,9 @@
               <text
                 id="node4_circle_text"
                 xml:space="default"
-                style="
-                  font-size: 19.7624px;
-                  font-family: sans-serif;
+                :style="`
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
                   direction: ltr;
@@ -1272,7 +1272,7 @@
                   fill: #000000;
                   stroke-width: 28.22049979;
                   stroke-dasharray: none;
-                "
+                `"
                 y="707.20343"
                 x="608.34302"
               >
@@ -1290,13 +1290,13 @@
               v-if="streetnameNode4.length > 1"
               id="node4_strassenname_multirow2_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -1311,26 +1311,26 @@
                 fill-opacity: 1;
                 stroke-width: 28.22049979;
                 stroke-dasharray: none;
-              "
+              `"
               x="437.52008"
               y="719.79083"
             >
               <tspan
                 id="node4_strassenname_multirow2_tspan"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 22.3767px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
                   stroke-width: 28.22049979;
                   stroke-dasharray: none;
-                "
+                `"
                 x="437.52008"
                 y="719.79083"
               >
@@ -1341,13 +1341,13 @@
               v-if="streetnameNode4.length > 1"
               id="node4_strassenname_multirow1_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -1362,26 +1362,26 @@
                 fill-opacity: 1;
                 stroke-width: 28.22049979;
                 stroke-dasharray: none;
-              "
+              `"
               x="437.52008"
               y="691.79083"
             >
               <tspan
                 id="node4_strassenname_multirow1_tspan"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 22.3767px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
                   stroke-width: 28.22049979;
                   stroke-dasharray: none;
-                "
+                `"
                 x="437.52008"
                 y="691.79083"
               >
@@ -1401,13 +1401,13 @@
                 id="node4_sum_text"
                 xml:space="preserve"
                 transform="rotate(-90)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1421,7 +1421,7 @@
                   fill-opacity: 1;
                   stroke-width: 28.22049972;
                   stroke-dasharray: none;
-                "
+                `"
                 x="-1347.438"
                 y="37.009583"
               >
@@ -1429,20 +1429,20 @@
                   id="node4_sum_tspan"
                   x="-189.98215"
                   y="825.1947"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: 28.097px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 28.22049972;
                     stroke-dasharray: none;
-                  "
+                  `"
                 >
                   {{ sumNode4Arrows }}
                 </tspan>
@@ -1621,16 +1621,16 @@
               <text
                 id="node5_circle_text"
                 xml:space="default"
-                style="
-                  font-size: 19.7624px;
-                  font-family: sans-serif;
+                :style="`
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
                   direction: ltr;
                   text-anchor: start;
                   fill: #000000;
                   stroke-width: 30.9229;
-                "
+                `"
                 y="646.03784"
                 x="754.23737"
               >
@@ -1648,13 +1648,13 @@
               v-if="streetnameNode5.length === 1"
               id="node5_strassenname_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -1668,7 +1668,7 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               transform="rotate(-45)"
               x="28.961172"
               y="919.29742"
@@ -1686,13 +1686,13 @@
               v-if="streetnameNode5.length > 1"
               id="node5_strassenname_multirow2_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -1706,7 +1706,7 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               transform="rotate(-45)"
               x="28.963634"
               y="933.29785"
@@ -1724,13 +1724,13 @@
               v-if="streetnameNode5.length > 1"
               id="node5_strassenname_multirow1_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -1744,7 +1744,7 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               transform="rotate(-45)"
               x="28.961161"
               y="905.2995"
@@ -1771,13 +1771,13 @@
                 id="node5_sum_text"
                 xml:space="preserve"
                 transform="rotate(-90)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -1791,7 +1791,7 @@
                   fill-opacity: 1;
                   stroke-width: 28.2205;
                   stroke-dasharray: none;
-                "
+                `"
                 x="-1347.4376"
                 y="36.689121"
               >
@@ -1799,20 +1799,20 @@
                   id="node5_sum_tspan"
                   x="-189.98169"
                   y="824.87433"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: 28.097px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 28.2205;
                     stroke-dasharray: none;
-                  "
+                  `"
                 >
                   {{ sumNode5Arrows }}
                 </tspan>
@@ -1969,13 +1969,13 @@
               v-if="streetnameNode6.length === 1"
               id="node6_strassenname_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -1989,7 +1989,7 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               transform="rotate(45)"
               x="1018.9124"
               y="-70.653908"
@@ -2025,16 +2025,16 @@
               <text
                 id="node6_circle_text"
                 xml:space="default"
-                style="
-                  font-size: 19.7624px;
-                  font-family: sans-serif;
+                :style="`
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
                   direction: ltr;
                   text-anchor: start;
                   fill: #000000;
                   stroke-width: 30.9229;
-                "
+                `"
                 y="1118.2867"
                 x="29.266506"
                 transform="rotate(-45)"
@@ -2053,13 +2053,13 @@
               v-if="streetnameNode6.length > 1"
               id="node6_strassenname_multirow2_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -2073,7 +2073,7 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               transform="rotate(45)"
               x="1018.9124"
               y="-56.651062"
@@ -2091,13 +2091,13 @@
               v-if="streetnameNode6.length > 1"
               id="node6_strassenname_multirow1_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -2111,7 +2111,7 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               transform="rotate(45)"
               x="1018.9124"
               y="-84.651779"
@@ -2134,13 +2134,13 @@
                 id="node6_sum_text"
                 xml:space="preserve"
                 transform="rotate(-90)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2154,7 +2154,7 @@
                   fill-opacity: 1;
                   stroke-width: 28.2205;
                   stroke-dasharray: none;
-                "
+                `"
                 x="-1349.311"
                 y="38.561497"
               >
@@ -2162,20 +2162,20 @@
                   id="node6_sum_tspan"
                   x="-191.85516"
                   y="826.7467"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: 28.097px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 28.2205;
                     stroke-dasharray: none;
-                  "
+                  `"
                 >
                   {{ sumNode6Arrows }}
                 </tspan>
@@ -2331,13 +2331,13 @@
               v-if="streetnameNode7.length === 1"
               id="node7_strassenname_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -2351,26 +2351,26 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               transform="rotate(-45)"
               x="-262.48056"
               y="995.74023"
             >
               <tspan
                 id="node7_strassenname_tspan"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 22.3767px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
                   stroke-width: 26.4927;
-                "
+                `"
                 x="-262.48056"
                 y="995.74023"
               >
@@ -2396,16 +2396,16 @@
               <text
                 id="node7_circle_text"
                 xml:space="default"
-                style="
-                  font-size: 19.7624px;
-                  font-family: sans-serif;
+                :style="`
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
                   direction: ltr;
                   text-anchor: start;
                   fill: #000000;
                   stroke-width: 30.9229;
-                "
+                `"
                 y="767.69238"
                 x="633.51685"
               >
@@ -2423,13 +2423,13 @@
               v-if="streetnameNode7.length > 1"
               id="node7_strassenname_multirow2_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -2443,26 +2443,26 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               transform="rotate(-45)"
               x="-262.48306"
               y="1009.7406"
             >
               <tspan
                 id="node7_strassenname_multirow2_tspan"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 22.3767px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
                   stroke-width: 26.4927;
-                "
+                `"
                 x="-262.48306"
                 y="1009.7406"
               >
@@ -2473,13 +2473,13 @@
               v-if="streetnameNode7.length > 1"
               id="node7_strassenname_multirow1_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -2493,26 +2493,26 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               transform="rotate(-45)"
               x="-262.48306"
               y="981.73987"
             >
               <tspan
                 id="node7_strassenname_multirow1_tspan"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 22.3767px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
                   stroke-width: 26.4927;
-                "
+                `"
                 x="-262.48306"
                 y="981.73987"
               >
@@ -2528,13 +2528,13 @@
                 id="node7_sum_text"
                 xml:space="preserve"
                 transform="rotate(-90)"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2548,7 +2548,7 @@
                   fill-opacity: 1;
                   stroke-width: 28.2205;
                   stroke-dasharray: none;
-                "
+                `"
                 x="-1347.4363"
                 y="36.689327"
               >
@@ -2556,20 +2556,20 @@
                   id="node7_sum_tspan"
                   x="-189.98039"
                   y="824.87451"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: 28.097px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 28.2205;
                     stroke-dasharray: none;
-                  "
+                  `"
                 >
                   {{ sumNode7Arrows }}
                 </tspan>
@@ -2725,13 +2725,13 @@
               v-if="streetnameNode8.length === 1"
               id="node8_strassenname_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -2745,26 +2745,26 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               x="727.46826"
               y="5.7913613"
               transform="rotate(45)"
             >
               <tspan
                 id="node8_strassenname_tspan"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 22.3767px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
                   stroke-width: 26.4927;
-                "
+                `"
                 x="727.46826"
                 y="5.7913613"
               >
@@ -2790,16 +2790,16 @@
               <text
                 id="node8_circle_text"
                 xml:space="default"
-                style="
-                  font-size: 19.7624px;
-                  font-family: sans-serif;
+                :style="`
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   text-align: start;
                   writing-mode: lr-tb;
                   direction: ltr;
                   text-anchor: start;
                   fill: #000000;
                   stroke-width: 30.9229;
-                "
+                `"
                 y="646.78491"
                 x="633.36969"
               >
@@ -2817,13 +2817,13 @@
               v-if="streetnameNode8.length > 1"
               id="node8_strassenname_multirow2_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -2837,26 +2837,26 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               x="727.47076"
               y="19.791721"
               transform="rotate(45)"
             >
               <tspan
                 id="node8_strassenname_multirow2_tspan"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 22.3767px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
                   stroke-width: 26.4927;
-                "
+                `"
                 x="727.47076"
                 y="19.791721"
               >
@@ -2867,13 +2867,13 @@
               v-if="streetnameNode8.length > 1"
               id="node8_strassenname_multirow1_text"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 22.3767px;
-                font-family: Arial;
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -2887,26 +2887,26 @@
                 fill: #000000;
                 fill-opacity: 1;
                 stroke-width: 26.4927;
-              "
+              `"
               x="727.47076"
               y="-8.2089996"
               transform="rotate(45)"
             >
               <tspan
                 id="node8_strassenname_multirow1_tspan"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: normal;
                   font-stretch: normal;
-                  font-size: 22.3767px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
                   font-variant-east-asian: normal;
                   stroke-width: 26.4927;
-                "
+                `"
                 x="727.47076"
                 y="-8.2089996"
               >
@@ -2922,13 +2922,13 @@
                 xml:space="preserve"
                 transform="rotate(-90)"
                 id="node8_sum_text"
-                style="
+                :style="`
                   font-style: normal;
                   font-variant: normal;
                   font-weight: bold;
                   font-stretch: normal;
-                  font-size: 28.097px;
-                  font-family: Arial;
+                  font-size: ${belastungsplanMethods.maxlineWidth}px;
+                  font-family: ${BelastungsplanConstants.fontfamily};
                   font-variant-ligatures: normal;
                   font-variant-caps: normal;
                   font-variant-numeric: normal;
@@ -2942,7 +2942,7 @@
                   fill-opacity: 1;
                   stroke-width: 28.2205;
                   stroke-dasharray: none;
-                "
+                `"
                 x="-1349.311"
                 y="38.561852"
               >
@@ -2950,20 +2950,20 @@
                   id="node8_sum_tspan"
                   x="-191.85516"
                   y="826.74701"
-                  style="
+                  :style="`
                     font-style: normal;
                     font-variant: normal;
                     font-weight: bold;
                     font-stretch: normal;
-                    font-size: 28.097px;
-                    font-family: Arial;
+                    font-size: ${belastungsplanMethods.maxlineWidth}px;
+                    font-family: ${BelastungsplanConstants.fontfamily};
                     font-variant-ligatures: normal;
                     font-variant-caps: normal;
                     font-variant-numeric: normal;
                     font-variant-east-asian: normal;
                     stroke-width: 28.2205;
                     stroke-dasharray: none;
-                  "
+                  `"
                 >
                   {{ sumNode8Arrows }}
                 </tspan>
@@ -3116,13 +3116,13 @@
           <text
             id="verkehrsart"
             xml:space="preserve"
-            style="
+            :style="`
               font-style: normal;
               font-variant: normal;
               font-weight: normal;
               font-stretch: normal;
-              font-size: 19.7556px;
-              font-family: sans-serif;
+              font-size: ${belastungsplanMethods.maxlineWidth}px;
+              font-family: ${BelastungsplanConstants.fontfamily};
               font-variant-ligatures: normal;
               font-variant-caps: normal;
               font-variant-numeric: normal;
@@ -3137,7 +3137,7 @@
               fill: #000000;
               stroke-width: 28.2205;
               stroke-dasharray: none;
-            "
+            `"
             x="168.24969"
             y="1230.3373"
             transform="matrix(1.000004,0,0,1,-152.56418,35.000043)"
@@ -3163,13 +3163,13 @@
             <text
               id="zaehlzeit2-multirow"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 19.7556px;
-                font-family: sans-serif;
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -3184,7 +3184,7 @@
                 fill: #000000;
                 stroke-width: 28.2205;
                 stroke-dasharray: none;
-              "
+              `"
               x="168"
               y="1210"
             >
@@ -3204,13 +3204,13 @@
             <text
               id="zaehlzeit1-multirow"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 19.7556px;
-                font-family: sans-serif;
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -3225,7 +3225,7 @@
                 fill: #000000;
                 stroke-width: 28.2205;
                 stroke-dasharray: none;
-              "
+              `"
               x="168.24969"
               y="1190.3373"
               transform="translate(-150.84646,0.00162031)"
@@ -3267,13 +3267,13 @@
           <text
             id="compass1"
             xml:space="default"
-            style="
+            :style="`
               font-style: normal;
               font-variant: normal;
               font-weight: normal;
               font-stretch: normal;
-              font-size: 24.6944px;
-              font-family: RomanD;
+              font-size: ${belastungsplanMethods.maxlineWidth}px;
+              font-family: ${BelastungsplanConstants.fontfamily};
               font-variant-ligatures: normal;
               font-variant-caps: normal;
               font-variant-numeric: normal;
@@ -3284,25 +3284,25 @@
               text-anchor: start;
               fill: #000000;
               stroke-width: 2.2868;
-            "
+            `"
             x="141.28348"
             y="93.924416"
           >
             <tspan
               id="tspan6"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 24.6944px;
-                font-family: RomanD;
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
                 font-variant-east-asian: normal;
                 stroke-width: 2.2868;
-              "
+              `"
             >
               N
             </tspan>
@@ -3320,13 +3320,13 @@
             <text
               id="zaehlstelle2-multirow"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 19.7556px;
-                font-family: sans-serif;
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -3341,7 +3341,7 @@
                 fill: #000000;
                 stroke-width: 28.2205;
                 stroke-dasharray: none;
-              "
+              `"
               x="699.24969"
               y="688.33734"
               transform="translate(324.11416)"
@@ -3376,13 +3376,13 @@
             <text
               id="zaehlstelle1-multirow"
               xml:space="preserve"
-              style="
+              :style="`
                 font-style: normal;
                 font-variant: normal;
                 font-weight: normal;
                 font-stretch: normal;
-                font-size: 19.7556px;
-                font-family: sans-serif;
+                font-size: ${belastungsplanMethods.maxlineWidth}px;
+                font-family: ${BelastungsplanConstants.fontfamily};
                 font-variant-ligatures: normal;
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
@@ -3397,7 +3397,7 @@
                 fill: #000000;
                 stroke-width: 28.2205;
                 stroke-dasharray: none;
-              "
+              `"
               x="699.24969"
               y="688.33734"
               transform="translate(324.11416)"
@@ -3453,6 +3453,7 @@ import {
 } from "@/util/Querungspruefung";
 import { useQu } from "@/util/QuUtils";
 import { useStrassennameUtils } from "@/util/StrassennameUtils";
+import { useBelastungsplanMethods } from "@/components/zaehlstelle/charts/BelastungsplanMethods";
 
 interface Props {
   data: LadeBelastungsplanDTO;
@@ -3466,6 +3467,7 @@ const props = withDefaults(defineProps<Props>(), {
 const zaehlstelleStore = useZaehlstelleStore();
 const display = useDisplay();
 const dateUtils = useDateUtils();
+const belastungsplanMethods = useBelastungsplanMethods();
 
 const sizeBelastungsplan = computed(() => {
   let sizeBelastungsplanSvg: number = zaehlstelleStore.getSizeBelastungsplanSvg;

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanQuSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanQuSvg.vue
@@ -204,7 +204,7 @@
               <text
                 id="node1_sum_text"
                 xml:space="preserve"
-                transform="matrix(0,-0.86675092,1.153734,0,0,0)"
+                transform="rotate(-90)"
                 style="
                   font-style: normal;
                   font-variant: normal;
@@ -226,13 +226,13 @@
                   stroke-width: 28.2205;
                   stroke-dasharray: none;
                 "
-                x="-1383.7572"
-                y="-70.255974"
+                x="-1347.4354"
+                y="37.009502"
               >
                 <tspan
                   id="node1_sum_tspan"
-                  x="-226.30139"
-                  y="717.9292"
+                  x="-189.97949"
+                  y="825.1947"
                   style="
                     font-style: normal;
                     font-variant: normal;
@@ -288,7 +288,6 @@
               v-if="node1WestToEastCensusComissioned"
               id="arrow_node1_west_to_east_number_text"
               xml:space="preserve"
-              transform="scale(0.87251096,1.1461174)"
               :fill="textColorArrowNode1WestToEast"
               style="
                 font-style: normal;
@@ -311,13 +310,13 @@
                 stroke-width: 28.22049989;
                 stroke-dasharray: none;
               "
-              x="-362.89398"
-              y="-553.82526"
+              x="-465.17621"
+              y="-520.35779"
             >
               <tspan
                 id="arrow_node1_west_to_east_number_tspan"
-                x="801.39209"
-                y="239.01094"
+                x="699.1098"
+                y="272.47839"
                 style="
                   font-style: normal;
                   font-variant: normal;
@@ -340,7 +339,6 @@
               v-if="node1EastToWestCensusComissioned"
               id="arrow_node1_east_to_west_number_text"
               xml:space="preserve"
-              transform="scale(0.87251096,1.1461174)"
               :fill="textColorArrowNode1EastToWest"
               style="
                 font-style: normal;
@@ -363,13 +361,13 @@
                 stroke-width: 28.22049989;
                 stroke-dasharray: none;
               "
-              x="-362.89325"
-              y="-599.6322"
+              x="-465.17548"
+              y="-572.85791"
             >
               <tspan
                 id="arrow_node1_east_to_west_number_tspan"
-                x="801.39209"
-                y="193.2041"
+                x="699.1098"
+                y="219.97839"
                 style="
                   font-style: normal;
                   font-variant: normal;
@@ -578,7 +576,7 @@
               <text
                 id="node2_sum_text"
                 xml:space="preserve"
-                transform="matrix(0,-0.86675092,1.153734,0,0,0)"
+                transform="rotate(-90)"
                 style="
                   font-style: normal;
                   font-variant: normal;
@@ -600,13 +598,13 @@
                   stroke-width: 28.2205;
                   stroke-dasharray: none;
                 "
-                x="-1383.7572"
-                y="-70.255974"
+                x="-1347.438"
+                y="37.009502"
               >
                 <tspan
                   id="node2_sum_tspan"
-                  x="-226.30139"
-                  y="717.9292"
+                  x="-189.98215"
+                  y="825.1947"
                   style="
                     font-style: normal;
                     font-variant: normal;
@@ -663,7 +661,7 @@
               v-if="node2NorthToSouthCensusComissioned"
               id="arrow_node2_north_to_south_number_text"
               xml:space="preserve"
-              transform="matrix(0,-0.86707182,1.153307,0,0,0)"
+              transform="rotate(-90)"
               :fill="textColorArrowNode2NorthToSouth"
               style="
                 font-style: normal;
@@ -686,13 +684,13 @@
                 stroke-width: 28.22049979;
                 stroke-dasharray: none;
               "
-              x="-1965.2267"
-              y="208.31508"
+              x="-1857.6315"
+              y="359.45795"
             >
               <tspan
                 id="arrow_node2_north_to_south_number_tspan"
-                x="-808.19946"
-                y="996.2088"
+                x="-700.60413"
+                y="1147.3517"
                 style="
                   font-style: normal;
                   font-variant: normal;
@@ -715,7 +713,7 @@
               v-if="node2SouthToNorthCensusComissioned"
               id="arrow_node2_south_to_north_number_text"
               xml:space="preserve"
-              transform="matrix(0,-0.86707182,1.153307,0,0,0)"
+              transform="rotate(-90)"
               :fill="textColorArrowNode2SouthToNorth"
               style="
                 font-style: normal;
@@ -738,13 +736,13 @@
                 stroke-width: 28.22049979;
                 stroke-dasharray: none;
               "
-              x="-1965.2268"
-              y="253.83627"
+              x="-1857.6313"
+              y="411.95795"
             >
               <tspan
                 id="arrow_node2_south_to_north_number_tspan"
-                x="-808.19946"
-                y="1041.7301"
+                x="-700.60413"
+                y="1199.8517"
                 style="
                   font-style: normal;
                   font-variant: normal;
@@ -991,7 +989,7 @@
               <text
                 id="node3_sum_text"
                 xml:space="preserve"
-                transform="matrix(0,-0.86675092,1.153734,0,0,0)"
+                transform="rotate(-90)"
                 style="
                   font-style: normal;
                   font-variant: normal;
@@ -1013,13 +1011,13 @@
                   stroke-width: 28.2204997;
                   stroke-dasharray: none;
                 "
-                x="-1383.7572"
-                y="-70.255974"
+                x="-1347.437"
+                y="37.009521"
               >
                 <tspan
                   id="node3_sum_tspan"
-                  x="-226.30139"
-                  y="717.9292"
+                  x="-189.98125"
+                  y="825.1947"
                   style="
                     font-style: normal;
                     font-variant: normal;
@@ -1075,7 +1073,6 @@
               v-if="node3WestToEastCensusComissioned"
               id="arrow_node3_west_to_east_number_text"
               xml:space="preserve"
-              transform="scale(0.87251096,1.1461174)"
               :fill="textColorArrowNode3WestToEast"
               style="
                 font-style: normal;
@@ -1098,13 +1095,13 @@
                 stroke-width: 28.22049989;
                 stroke-dasharray: none;
               "
-              x="-362.89398"
-              y="255.42867"
+              x="-465.17621"
+              y="407.14215"
             >
               <tspan
                 id="arrow_node3_west_to_east_number_tspan"
-                x="801.39209"
-                y="1048.2649"
+                x="699.1098"
+                y="1199.9784"
                 style="
                   font-style: normal;
                   font-variant: normal;
@@ -1127,7 +1124,6 @@
               v-if="node3EastToWestCensusComissioned"
               id="arrow_node3_east_to_west_number_text"
               xml:space="preserve"
-              transform="scale(0.87251096,1.1461174)"
               :fill="textColorArrowNode3EastToWest"
               style="
                 font-style: normal;
@@ -1150,13 +1146,13 @@
                 stroke-width: 28.22049989;
                 stroke-dasharray: none;
               "
-              x="-362.89322"
-              y="209.62167"
+              x="-465.17545"
+              y="354.64206"
             >
               <tspan
                 id="arrow_node3_east_to_west_number_tspan"
-                x="801.39209"
-                y="1002.458"
+                x="699.1098"
+                y="1147.4784"
                 style="
                   font-style: normal;
                   font-variant: normal;
@@ -1404,7 +1400,7 @@
               <text
                 id="node4_sum_text"
                 xml:space="preserve"
-                transform="matrix(0,-0.86675092,1.153734,0,0,0)"
+                transform="rotate(-90)"
                 style="
                   font-style: normal;
                   font-variant: normal;
@@ -1426,13 +1422,13 @@
                   stroke-width: 28.22049972;
                   stroke-dasharray: none;
                 "
-                x="-1383.7572"
-                y="-70.255974"
+                x="-1347.438"
+                y="37.009583"
               >
                 <tspan
                   id="node4_sum_tspan"
-                  x="-226.30139"
-                  y="717.9292"
+                  x="-189.98215"
+                  y="825.1947"
                   style="
                     font-style: normal;
                     font-variant: normal;
@@ -1488,7 +1484,7 @@
             <text
               v-if="node4NorthToSouthCensusComissioned"
               xml:space="preserve"
-              transform="matrix(0,-0.86707182,1.153307,0,0,0)"
+              transform="rotate(-90)"
               id="arrow_node4_north_to_south_number_text"
               :fill="textColorArrowNode4NorthToSouth"
               style="
@@ -1512,12 +1508,12 @@
                 stroke-width: 28.2205;
                 stroke-dasharray: none;
               "
-              x="-1965.2267"
-              y="-595.89404"
+              x="-1857.6313"
+              y="-568.04199"
             >
               <tspan
-                x="-808.19946"
-                y="191.99969"
+                x="-700.60413"
+                y="219.85175"
                 id="arrow_node4_north_to_south_number_tspan"
                 style="
                   font-style: normal;
@@ -1540,7 +1536,7 @@
             <text
               v-if="node4SouthToNorthCensusComissioned"
               xml:space="preserve"
-              transform="matrix(0,-0.86707182,1.153307,0,0,0)"
+              transform="rotate(-90)"
               id="arrow_node4_south_to_north_number_text"
               :fill="textColorArrowNode4SouthToNorth"
               style="
@@ -1564,12 +1560,12 @@
                 stroke-width: 28.2205;
                 stroke-dasharray: none;
               "
-              x="-1965.2268"
-              y="-550.37286"
+              x="-1857.6316"
+              y="-515.54205"
             >
               <tspan
-                x="-808.19946"
-                y="237.52097"
+                x="-700.60413"
+                y="272.35175"
                 id="arrow_node4_south_to_north_number_tspan"
                 style="
                   font-style: normal;
@@ -1774,7 +1770,7 @@
               <text
                 id="node5_sum_text"
                 xml:space="preserve"
-                transform="matrix(0,-0.86675092,1.153734,0,0,0)"
+                transform="rotate(-90)"
                 style="
                   font-style: normal;
                   font-variant: normal;
@@ -1796,13 +1792,13 @@
                   stroke-width: 28.2205;
                   stroke-dasharray: none;
                 "
-                x="-1383.7572"
-                y="-70.255974"
+                x="-1347.4376"
+                y="36.689121"
               >
                 <tspan
                   id="node5_sum_tspan"
-                  x="-226.30139"
-                  y="717.9292"
+                  x="-189.98169"
+                  y="824.87433"
                   style="
                     font-style: normal;
                     font-variant: normal;
@@ -1859,7 +1855,7 @@
               v-if="node5NorthWestToSouthEastCensusComissioned"
               id="arrow_node5_north_west_to_south_east_number_text"
               xml:space="preserve"
-              transform="matrix(0.61695842,0.61695842,-0.81042739,0.81042739,-2.4668423e-8,4.2673751e-7)"
+              transform="rotate(45)"
               :fill="textColorArrowNode5NorthWestToSouthEast"
               style="
                 font-style: normal;
@@ -1881,13 +1877,13 @@
                 fill-opacity: 1;
                 stroke-width: 44.2239;
               "
-              x="-30.245787"
-              y="-1164.397"
+              x="-170.68669"
+              y="-1220.1736"
             >
               <tspan
                 id="arrow_node5_north_west_to_south_east_number_tspan"
-                x="1134.0402"
-                y="-371.56079"
+                x="993.59924"
+                y="-427.33743"
                 style="
                   font-style: normal;
                   font-variant: normal;
@@ -1909,7 +1905,7 @@
               v-if="node5SouthEastToNorthWestCensusComissioned"
               id="arrow_node5_south_east_to_north_west_number_text"
               xml:space="preserve"
-              transform="matrix(0.61695842,0.61695842,-0.81042739,0.81042739,-2.4668423e-8,4.2673751e-7)"
+              transform="rotate(45)"
               :fill="textColorArrowNode5SouthEastToNorthWest"
               style="
                 font-style: normal;
@@ -1931,13 +1927,13 @@
                 fill-opacity: 1;
                 stroke-width: 44.2239;
               "
-              x="-30.245035"
-              y="-1210.2013"
+              x="-170.68846"
+              y="-1272.6682"
             >
               <tspan
                 id="arrow_node5_south_east_to_north_west_number_tspan"
-                x="1134.0402"
-                y="-417.36499"
+                x="993.59674"
+                y="-479.83194"
                 style="
                   font-style: normal;
                   font-variant: normal;
@@ -2137,7 +2133,7 @@
               <text
                 id="node6_sum_text"
                 xml:space="preserve"
-                transform="matrix(0,-0.86675092,1.153734,0,0,0)"
+                transform="rotate(-90)"
                 style="
                   font-style: normal;
                   font-variant: normal;
@@ -2159,13 +2155,13 @@
                   stroke-width: 28.2205;
                   stroke-dasharray: none;
                 "
-                x="-1383.7572"
-                y="-70.255974"
+                x="-1349.311"
+                y="38.561497"
               >
                 <tspan
                   id="node6_sum_tspan"
-                  x="-226.30139"
-                  y="717.9292"
+                  x="-191.85516"
+                  y="826.7467"
                   style="
                     font-style: normal;
                     font-variant: normal;
@@ -2221,7 +2217,7 @@
               v-if="node6NorthEastToSouthWestCensusComissioned"
               id="arrow_node6_north_east_to_south_west_number_text"
               xml:space="preserve"
-              transform="matrix(0.61695842,-0.61695842,0.81042739,0.81042739,-2.9965742e-7,1.1586825e-8)"
+              transform="rotate(-45)"
               :fill="textColorArrowNode6NorthEastToSouthWest"
               style="
                 font-style: normal;
@@ -2243,13 +2239,13 @@
                 fill-opacity: 1;
                 stroke-width: 44.2239;
               "
-              x="-1165.1763"
-              y="463.03299"
+              x="-1172.4175"
+              y="644.03931"
             >
               <tspan
                 id="arrow_node6_north_east_to_south_west_number_tspan"
-                x="-0.89014673"
-                y="1255.8691"
+                x="-8.1312895"
+                y="1436.8754"
                 style="
                   font-style: normal;
                   font-variant: normal;
@@ -2271,7 +2267,7 @@
               v-if="node6SouthWestToNorthEastCensusComissioned"
               id="arrow_node6_south_west_to_north_east_number_text"
               xml:space="preserve"
-              transform="matrix(0.61695842,-0.61695842,0.81042739,0.81042739,-2.9965742e-7,1.1586825e-8)"
+              transform="rotate(-45)"
               :fill="textColorArrowNode6SouthWestToNorthEast"
               style="
                 font-style: normal;
@@ -2293,13 +2289,13 @@
                 fill-opacity: 1;
                 stroke-width: 44.2239;
               "
-              x="-1165.1754"
-              y="508.83719"
+              x="-1172.6617"
+              y="696.29114"
             >
               <tspan
                 id="arrow_node6_south_west_to_north_east_number_tspan"
-                x="-0.89011478"
-                y="1301.6733"
+                x="-8.3763189"
+                y="1489.1274"
                 style="
                   font-style: normal;
                   font-variant: normal;
@@ -2531,7 +2527,7 @@
               <text
                 id="node7_sum_text"
                 xml:space="preserve"
-                transform="matrix(0,-0.86675092,1.153734,0,0,0)"
+                transform="rotate(-90)"
                 style="
                   font-style: normal;
                   font-variant: normal;
@@ -2553,13 +2549,13 @@
                   stroke-width: 28.2205;
                   stroke-dasharray: none;
                 "
-                x="-1383.7572"
-                y="-70.255974"
+                x="-1347.4363"
+                y="36.689327"
               >
                 <tspan
                   id="node7_sum_tspan"
-                  x="-226.30139"
-                  y="717.9292"
+                  x="-189.98039"
+                  y="824.87451"
                   style="
                     font-style: normal;
                     font-variant: normal;
@@ -2615,7 +2611,7 @@
               v-if="node7SouthEastToNorthWestCensusComissioned"
               id="arrow_node7_south_east_to_north_west_number_text"
               xml:space="preserve"
-              transform="matrix(0.61695842,0.61695842,-0.81042739,0.81042739,-3.0764013e-7,0)"
+              transform="rotate(45)"
               :fill="textColorArrowNode7SouthEastToNorthWest"
               style="
                 font-style: normal;
@@ -2637,13 +2633,13 @@
                 fill-opacity: 1;
                 stroke-width: 44.2239;
               "
-              x="-30.018866"
-              y="-401.13431"
+              x="-170.48979"
+              y="-345.38342"
             >
               <tspan
                 id="arrow_node7_south_east_to_north_west_number_tspan"
-                x="1134.2671"
-                y="391.7019"
+                x="993.79614"
+                y="447.45276"
                 style="
                   font-style: normal;
                   font-variant: normal;
@@ -2665,7 +2661,7 @@
               v-if="node7NorthWestToSouthEastCensusComissioned"
               id="arrow_node7_north_west_to_south_east_number_text"
               xml:space="preserve"
-              transform="matrix(0.61695842,0.61695842,-0.81042739,0.81042739,-3.0764013e-7,0)"
+              transform="rotate(45)"
               :fill="textColorArrowNode7NorthWestToSouthEast"
               style="
                 font-style: normal;
@@ -2687,13 +2683,13 @@
                 fill-opacity: 1;
                 stroke-width: 44.2239;
               "
-              x="-30.018135"
-              y="-355.33026"
+              x="-170.48906"
+              y="-292.88657"
             >
               <tspan
                 id="arrow_node7_north_west_to_south_east_number_tspan"
-                x="1134.2671"
-                y="437.50613"
+                x="993.79614"
+                y="499.94977"
                 style="
                   font-style: normal;
                   font-variant: normal;
@@ -2924,7 +2920,7 @@
             >
               <text
                 xml:space="preserve"
-                transform="matrix(0,-0.86675092,1.153734,0,0,0)"
+                transform="rotate(-90)"
                 id="node8_sum_text"
                 style="
                   font-style: normal;
@@ -2947,13 +2943,13 @@
                   stroke-width: 28.2205;
                   stroke-dasharray: none;
                 "
-                x="-1383.7572"
-                y="-70.255974"
+                x="-1349.311"
+                y="38.561852"
               >
                 <tspan
                   id="node8_sum_tspan"
-                  x="-226.30139"
-                  y="717.9292"
+                  x="-191.85516"
+                  y="826.74701"
                   style="
                     font-style: normal;
                     font-variant: normal;
@@ -3009,7 +3005,7 @@
               v-if="node8SouthWestToNorthEastCensusComissioned"
               id="arrow_node8_south_west_to_north_east_number_text"
               xml:space="preserve"
-              transform="matrix(0.61695842,-0.61695842,0.81042739,0.81042739,-4.3344642e-8,-4.1388365e-7)"
+              transform="rotate(-45)"
               :fill="textColorArrowNode8SouthWestToNorthEast"
               style="
                 font-style: normal;
@@ -3031,13 +3027,13 @@
                 fill-opacity: 1;
                 stroke-width: 44.2239;
               "
-              x="-1165.4031"
-              y="-300.22974"
+              x="-1171.1313"
+              y="-283.24542"
             >
               <tspan
                 id="arrow_node8_south_west_to_north_east_number_tspan"
-                x="-1.1170298"
-                y="492.60648"
+                x="-6.8456869"
+                y="509.59097"
                 style="
                   font-style: normal;
                   font-variant: normal;
@@ -3059,7 +3055,7 @@
               v-if="node8NorthEastToSouthWestCensusComissioned"
               id="arrow_node8_north_east_to_south_west_number_text"
               xml:space="preserve"
-              transform="matrix(0.61695842,-0.61695842,0.81042739,0.81042739,-4.3344642e-8,-4.1388365e-7)"
+              transform="rotate(-45)"
               :fill="textColorArrowNode8NorthEastToSouthWest"
               style="
                 font-style: normal;
@@ -3081,13 +3077,13 @@
                 fill-opacity: 1;
                 stroke-width: 44.2239;
               "
-              x="-1165.4023"
-              y="-346.03415"
+              x="-1172.6158"
+              y="-231.24287"
             >
               <tspan
                 id="arrow_node8_north_east_to_south_west_number_tspan"
-                x="-1.117029"
-                y="446.80225"
+                x="-8.3306265"
+                y="561.59302"
                 style="
                   font-style: normal;
                   font-variant: normal;

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanQuSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanQuSvg.vue
@@ -3104,14 +3104,10 @@
           </g>
         </g>
       </g>
-      <g
-        id="legend"
-        transform="matrix(1.0449912,0,0,1.0489734,-20.934144,-1.2761587)"
-      >
+      <g id="legend">
         <g
           id="legend-zaehlinfo"
           style="stroke-width: 28.2205; stroke-dasharray: none"
-          transform="translate(50.006244,31.659644)"
         >
           <text
             id="verkehrsart"
@@ -3138,14 +3134,13 @@
               stroke-width: 28.2205;
               stroke-dasharray: none;
             `"
-            x="168.24969"
-            y="1230.3373"
-            transform="matrix(1.000004,0,0,1,-152.56418,35.000043)"
+            x="56.249691"
+            y="1310.3373"
           >
             <tspan
               id="tspan35"
-              x="168.24969"
-              y="1230.3373"
+              x="56.249691"
+              y="1310.3373"
             >
               <tspan
                 id="tspan34"
@@ -3158,7 +3153,6 @@
           <g
             id="zaehlzeit2"
             style="stroke-width: 28.2205; stroke-dasharray: none"
-            transform="translate(-152.29421)"
           >
             <text
               id="zaehlzeit2-multirow"
@@ -3185,13 +3179,13 @@
                 stroke-width: 28.2205;
                 stroke-dasharray: none;
               `"
-              x="168"
-              y="1210"
+              x="56.249691"
+              y="1257"
             >
               <tspan
                 id="tspan36"
-                x="168"
-                y="1210"
+                x="56.249691"
+                y="1257"
               >
                 {{ zaehlzeit2 }}
               </tspan>
@@ -3226,14 +3220,13 @@
                 stroke-width: 28.2205;
                 stroke-dasharray: none;
               `"
-              x="168.24969"
-              y="1190.3373"
-              transform="translate(-150.84646,0.00162031)"
+              x="56.249691"
+              y="1230.3373"
             >
               <tspan
                 id="tspan38"
-                x="168.24969"
-                y="1190.3373"
+                x="56.249691"
+                y="1230.3373"
               >
                 <tspan
                   id="tspan37"
@@ -3245,24 +3238,20 @@
             </text>
           </g>
         </g>
-        <g
-          id="legend-compass"
-          transform="matrix(0.79169692,0,0,0.78817168,-25.092397,5.5190685)"
-        >
+        <g id="legend-compass">
           <path
             id="compass2"
             style="
               fill: none;
               fill-opacity: 1;
-              stroke: #000000;
-              stroke-width: 3.35093;
+              stroke: #666666;
+              stroke-width: 1.99499999;
               stroke-linecap: butt;
               stroke-miterlimit: 2.5;
               stroke-dasharray: none;
               stroke-opacity: 1;
             "
-            d="m 399.4343,-24.60083 105.23313,182.26914 -210.46627,-1e-5 z"
-            transform="matrix(0.16996929,0,0,0.4104001,81.91578,36.842952)"
+            d="m 107.4337,29.984176 13.9217,63.312817 H 106.06607 93.511995 Z"
           />
           <text
             id="compass1"
@@ -3282,11 +3271,11 @@
               writing-mode: lr-tb;
               direction: ltr;
               text-anchor: start;
-              fill: #000000;
+              fill: #666666;
               stroke-width: 2.2868;
             `"
-            x="141.28348"
-            y="93.924416"
+            x="100.26942"
+            y="84.035934"
           >
             <tspan
               id="tspan6"
@@ -3301,21 +3290,17 @@
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
                 font-variant-east-asian: normal;
-                stroke-width: 2.2868;
+                stroke-width: 43.9644;
               `"
             >
               N
             </tspan>
           </text>
         </g>
-        <g
-          id="legend-zaehlstelle"
-          transform="translate(-112.62637,-13.999124)"
-        >
+        <g id="legend-zaehlstelle">
           <g
             id="zaehlstelle2"
             style="stroke-width: 28.2205; stroke-dasharray: none"
-            transform="translate(163.18555,-589.09456)"
           >
             <text
               id="zaehlstelle2-multirow"
@@ -3342,22 +3327,21 @@
                 stroke-width: 28.2205;
                 stroke-dasharray: none;
               `"
-              x="699.24969"
-              y="688.33734"
-              transform="translate(324.11416)"
+              x="1107.2496"
+              y="85.837341"
             >
               <tspan
                 id="tspan39"
-                x="699.24969"
-                y="688.33734"
+                x="1107.2496"
+                y="85.837341"
               >
                 Stadtbezirk
                 {{ zaehlstelleStore.getZaehlstelleHeader.stadtbezirkNummer }}
               </tspan>
               <tspan
                 id="tspan40"
-                x="699.24969"
-                y="713.03187"
+                x="1107.2496"
+                y="112.26053"
               >
                 Zähldatum:
                 {{
@@ -3371,7 +3355,6 @@
           <g
             id="zaehlstelle1"
             style="stroke-width: 28.2205; stroke-dasharray: none"
-            transform="translate(162.09712,-614.70735)"
           >
             <text
               id="zaehlstelle1-multirow"
@@ -3398,14 +3381,13 @@
                 stroke-width: 28.2205;
                 stroke-dasharray: none;
               `"
-              x="699.24969"
-              y="688.33734"
-              transform="translate(324.11416)"
+              x="1107.2496"
+              y="60.337341"
             >
               <tspan
                 id="tspan42"
-                x="699.24969"
-                y="688.33734"
+                x="1107.2496"
+                y="60.337341"
               >
                 <tspan
                   id="tspan41"
@@ -3440,6 +3422,7 @@ import { computed, nextTick, onMounted, ref, watch } from "vue";
 import { useDisplay } from "vuetify/framework";
 
 import { BelastungsplanConstants } from "@/components/zaehlstelle/charts/BelastungsplanConstants";
+import { useBelastungsplanMethods } from "@/components/zaehlstelle/charts/BelastungsplanMethods";
 import { useZaehlstelleStore } from "@/store/ZaehlstelleStore";
 import Himmelsrichtung from "@/types/enum/Himmelsrichtung";
 import Zaehldauer from "@/types/enum/Zaehldauer";
@@ -3453,7 +3436,6 @@ import {
 } from "@/util/Querungspruefung";
 import { useQu } from "@/util/QuUtils";
 import { useStrassennameUtils } from "@/util/StrassennameUtils";
-import { useBelastungsplanMethods } from "@/components/zaehlstelle/charts/BelastungsplanMethods";
 
 interface Props {
   data: LadeBelastungsplanDTO;

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanQuSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanQuSvg.vue
@@ -3327,21 +3327,21 @@
                 stroke-width: 28.2205;
                 stroke-dasharray: none;
               `"
-              x="1107.2496"
-              y="85.837341"
+              x="1107.0699"
+              y="84.662277"
             >
               <tspan
                 id="tspan39"
-                x="1107.2496"
-                y="85.837341"
+                x="1107.0699"
+                y="84.662277"
               >
                 Stadtbezirk
                 {{ zaehlstelleStore.getZaehlstelleHeader.stadtbezirkNummer }}
               </tspan>
               <tspan
                 id="tspan40"
-                x="1107.2496"
-                y="112.26053"
+                x="1107.0699"
+                y="110.83184"
               >
                 Zähldatum:
                 {{
@@ -3381,13 +3381,13 @@
                 stroke-width: 28.2205;
                 stroke-dasharray: none;
               `"
-              x="1107.2496"
-              y="60.337341"
+              x="1107.0699"
+              y="58.662277"
             >
               <tspan
                 id="tspan42"
-                x="1107.2496"
-                y="60.337341"
+                x="1107.0699"
+                y="58.662277"
               >
                 <tspan
                   id="tspan41"

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanQuSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanQuSvg.vue
@@ -3134,13 +3134,13 @@
               stroke-width: 28.2205;
               stroke-dasharray: none;
             `"
-            x="56.249691"
-            y="1310.3373"
+            x="56"
+            y="1307.6622"
           >
             <tspan
               id="tspan35"
-              x="56.249691"
-              y="1310.3373"
+              x="56"
+              y="1307.6622"
             >
               <tspan
                 id="tspan34"
@@ -3179,13 +3179,13 @@
                 stroke-width: 28.2205;
                 stroke-dasharray: none;
               `"
-              x="56.249691"
-              y="1257"
+              x="56"
+              y="1255.6622"
             >
               <tspan
                 id="tspan36"
-                x="56.249691"
-                y="1257"
+                x="56"
+                y="1255.6622"
               >
                 {{ zaehlzeit2 }}
               </tspan>
@@ -3220,13 +3220,13 @@
                 stroke-width: 28.2205;
                 stroke-dasharray: none;
               `"
-              x="56.249691"
-              y="1230.3373"
+              x="56"
+              y="1229.6622"
             >
               <tspan
                 id="tspan38"
-                x="56.249691"
-                y="1230.3373"
+                x="56"
+                y="1229.6622"
               >
                 <tspan
                   id="tspan37"

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanQuSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanQuSvg.vue
@@ -3241,17 +3241,17 @@
         <g id="legend-compass">
           <path
             id="compass2"
-            style="
+            :style="`
               fill: none;
               fill-opacity: 1;
-              stroke: #666666;
-              stroke-width: 1.99499999;
+              stroke: ${BelastungsplanConstants.legendColor};
+              stroke-width: 2;
               stroke-linecap: butt;
               stroke-miterlimit: 2.5;
               stroke-dasharray: none;
               stroke-opacity: 1;
-            "
-            d="m 107.4337,29.984176 13.9217,63.312817 H 106.06607 93.511995 Z"
+            `"
+            d="m 93.333333,93.333333 h 27.999997 l -14,-63 z"
           />
           <text
             id="compass1"
@@ -3270,12 +3270,12 @@
               text-align: start;
               writing-mode: lr-tb;
               direction: ltr;
-              text-anchor: start;
-              fill: #666666;
-              stroke-width: 2.2868;
+              text-anchor: middle;
+              fill: ${BelastungsplanConstants.legendColor};
+              stroke-width: 2;
             `"
-            x="100.26942"
-            y="84.035934"
+            x="107.33477"
+            y="83.332977"
           >
             <tspan
               id="tspan6"
@@ -3290,7 +3290,7 @@
                 font-variant-caps: normal;
                 font-variant-numeric: normal;
                 font-variant-east-asian: normal;
-                stroke-width: 43.9644;
+                stroke-width: 2;
               `"
             >
               N


### PR DESCRIPTION
# Description

- removed compression of zaehlwert numbers
- set correct font styles
- adjusted legend position to match with previous BLPs

# Issue References

FV-373
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [x] Acceptance criteria are met
- [x] Testing is done (unit-tests, DEV-environment)
- [x] Build/Test workflow has successfully finished
- [x] Release notes are complemented
- [x] Documentation is complemented (operator manual, system specification, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved visual layout and positioning of chart elements in load plan diagrams.
  * Standardized text styling and legend rendering across chart components for consistency.
  * Applied dynamic color and font settings for better visual coherence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->