### PR TITLE
FV-374 Leere Tabs nach Zählstellenwechsel über die kleine Karte

### DIFF
--- a/frontend/src/components/zaehlstelle/ZaehldatenDiagramme.vue
+++ b/frontend/src/components/zaehlstelle/ZaehldatenDiagramme.vue
@@ -370,6 +370,10 @@ const isNotTabHeatmap = computed<boolean>(() => {
   return TAB_HEATMAP !== activeTab.value;
 });
 
+watch(selectedZaehlung, () => {
+  changeTab();
+});
+
 watch(options, () => {
   displaySchema.value = true;
   loadData();


### PR DESCRIPTION
# Description

Fixes a bug, where the Belastungsplan was not shown after switching to another counting via the small map inside a counting.

Uses fix from https://github.com/starwit/dave-frontend/pull/12/changes

# Issue References

FV-374
#603
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [x] Acceptance criteria are met
- [x] Testing is done (unit-tests, DEV-environment)
- [x] Build/Test workflow has successfully finished
- [x] Release notes are complemented
- [x] Documentation is complemented (operator manual, system specification, etc.)