### PR TITLE
Bug FV-371 Zeitreihe BLP Anzeige

### DIFF
--- a/frontend/src/components/zaehlstelle/optionsmenue/panels/FahrzeugPanel.vue
+++ b/frontend/src/components/zaehlstelle/optionsmenue/panels/FahrzeugPanel.vue
@@ -560,10 +560,14 @@ const helpTextFahrzeugkategorien = computed(() => {
 
 /**
  * Hilfsmethode, um zu schauen, ob der Wert SV% im Belastungsplan angezeigt wird.
- * Dies ist nur der Fall, wenn KFZ, SV oder SV aktiviert sind und inklusive SV_P nicht
- * mehr wie 3 Verkehrsarten (ohne RAD und FUSS) ausgewählt sind
+ * Dies ist nur der Fall, wenn KFZ, SV oder GV aktiviert sind und inklusive SV_P nicht
+ * mehr wie 3 Verkehrsarten (ohne RAD und FUSS) ausgewählt sind.
+ * Im Fall der Differenzdatendarstellung wird SV% nie angezeigt.
  */
 const isSvpInBelastungsPlan = computed(() => {
+  if (isDifferenzdatenDarstellung) {
+    return false;
+  }
   let actualNumberOfSelectedKfzSvAndGv = 0;
   chosenOptionsCopy.value.kraftfahrzeugverkehr
     ? actualNumberOfSelectedKfzSvAndGv++
@@ -586,9 +590,13 @@ const isSvpInBelastungsPlan = computed(() => {
 /**
  * Hilfsmethode, um zu schauen, ob der Wert GV% im Belastungsplan angezeigt wird.
  * Dies ist nur der Fall, wenn KFZ, SV oder GV aktiviert sind und inklusive GV_P nicht
- * mehr wie 3 Verkehrsarten (ohne RAD und FUSS) ausgewählt sind
+ * mehr wie 3 Verkehrsarten (ohne RAD und FUSS) ausgewählt sind.
+ * Im Fall der Differenzdatendarstellung wird GV% nie angezeigt.
  */
 const isGvpInBelastungsPlan = computed(() => {
+  if (isDifferenzdatenDarstellung) {
+    return false;
+  }
   let actualNumberOfSelectedKfzSvGvAndSV_P = 0;
   chosenOptionsCopy.value.kraftfahrzeugverkehr
     ? actualNumberOfSelectedKfzSvGvAndSV_P++

--- a/frontend/src/components/zaehlstelle/optionsmenue/panels/FahrzeugPanel.vue
+++ b/frontend/src/components/zaehlstelle/optionsmenue/panels/FahrzeugPanel.vue
@@ -417,6 +417,7 @@
 import type LadeZaehlungDTO from "@/types/zaehlung/LadeZaehlungDTO";
 import type ZaehlstelleOptionsDTO from "@/types/zaehlung/ZaehlstelleOptionsDTO";
 
+import { isEmpty } from "lodash";
 import { computed, onMounted, ref, watch } from "vue";
 
 import PanelHeader from "@/components/common/PanelHeader.vue";
@@ -651,7 +652,7 @@ const labelSelectOrDeselectAllVerkehrsarten = computed(() => {
 const isDifferenzdatenDarstellung = computed(() => {
   return (
     chosenOptionsCopy.value.differenzdatenDarstellen &&
-    chosenOptionsCopy.value.vergleichszaehlungsId != null
+    !isEmpty(chosenOptionsCopy.value.vergleichszaehlungsId)
   );
 });
 

--- a/frontend/src/components/zaehlstelle/optionsmenue/panels/FahrzeugPanel.vue
+++ b/frontend/src/components/zaehlstelle/optionsmenue/panels/FahrzeugPanel.vue
@@ -756,13 +756,13 @@ function getHintToDisplay(type: string): string {
       break;
     }
     case "SV_P": {
-      if (chosenOptionsCopy.value.differenzdatenDarstellen) {
+      if (isDifferenzdatenDarstellung.value) {
         hint = "Schwerverkehrsanteil bei Differenzdatenvergleich deaktiviert.";
       }
       break;
     }
     case "GV_P": {
-      if (chosenOptionsCopy.value.differenzdatenDarstellen) {
+      if (isDifferenzdatenDarstellung.value) {
         hint = "Güterverkehrsanteil bei Differenzdatenvergleich deaktiviert.";
       }
       break;

--- a/frontend/src/components/zaehlstelle/optionsmenue/panels/FahrzeugPanel.vue
+++ b/frontend/src/components/zaehlstelle/optionsmenue/panels/FahrzeugPanel.vue
@@ -127,9 +127,7 @@
                   isTypeDisabled('SV_P') ||
                   isDifferenzdatenDarstellung
                 "
-                :disabled="
-                  isTypeDisabled('SV_P')
-                "
+                :disabled="isTypeDisabled('SV_P')"
                 :hide-details="!isDifferenzdatenDarstellung"
                 density="compact"
                 @mouseover="hoverSv_p = true"
@@ -189,11 +187,10 @@
                 :color="getCheckboxColor('GV_P')"
                 :persistent-hint="
                   chosenOptionsCopy.gueterverkehrsanteilProzent ||
-                  isTypeDisabled('GV_P') || isDifferenzdatenDarstellung
+                  isTypeDisabled('GV_P') ||
+                  isDifferenzdatenDarstellung
                 "
-                :disabled="
-                  isTypeDisabled('GV_P')
-                "
+                :disabled="isTypeDisabled('GV_P')"
                 :hide-details="!isDifferenzdatenDarstellung"
                 density="compact"
                 @mouseover="hoverGv_p = true"
@@ -652,8 +649,11 @@ const labelSelectOrDeselectAllVerkehrsarten = computed(() => {
 });
 
 const isDifferenzdatenDarstellung = computed(() => {
-  return chosenOptionsCopy.value.differenzdatenDarstellen && chosenOptionsCopy.value.vergleichszaehlungsId != null
-})
+  return (
+    chosenOptionsCopy.value.differenzdatenDarstellen &&
+    chosenOptionsCopy.value.vergleichszaehlungsId != null
+  );
+});
 
 /**
  * Hilfsmethode, um alle Checkboxen der Fahrzeugkategorien aufeinmal

--- a/frontend/src/components/zaehlstelle/optionsmenue/panels/FahrzeugPanel.vue
+++ b/frontend/src/components/zaehlstelle/optionsmenue/panels/FahrzeugPanel.vue
@@ -125,13 +125,12 @@
                 :persistent-hint="
                   chosenOptionsCopy.schwerverkehrsanteilProzent ||
                   isTypeDisabled('SV_P') ||
-                  chosenOptionsCopy.differenzdatenDarstellen
+                  isDifferenzdatenDarstellung
                 "
                 :disabled="
-                  isTypeDisabled('SV_P') ||
-                  chosenOptionsCopy.differenzdatenDarstellen
+                  isTypeDisabled('SV_P')
                 "
-                :hide-details="!chosenOptionsCopy.differenzdatenDarstellen"
+                :hide-details="!isDifferenzdatenDarstellung"
                 density="compact"
                 @mouseover="hoverSv_p = true"
                 @mouseleave="hoverSv_p = false"
@@ -190,14 +189,12 @@
                 :color="getCheckboxColor('GV_P')"
                 :persistent-hint="
                   chosenOptionsCopy.gueterverkehrsanteilProzent ||
-                  isTypeDisabled('GV_P') ||
-                  chosenOptionsCopy.differenzdatenDarstellen
+                  isTypeDisabled('GV_P') || isDifferenzdatenDarstellung
                 "
                 :disabled="
-                  isTypeDisabled('GV_P') ||
-                  chosenOptionsCopy.differenzdatenDarstellen
+                  isTypeDisabled('GV_P')
                 "
-                :hide-details="!chosenOptionsCopy.differenzdatenDarstellen"
+                :hide-details="!isDifferenzdatenDarstellung"
                 density="compact"
                 @mouseover="hoverGv_p = true"
                 @mouseleave="hoverGv_p = false"
@@ -441,11 +438,6 @@ const zaehlstelleStore = useZaehlstelleStore();
 const zaehlstelleUtils = useZaehlstelleUtils();
 const globalInfoMessage = useGlobalInfoMessage();
 
-// Bei Auswahl der Checkbox für einen Differenzdatenvergleich werden die Werte für SV- und GV-Anteil in Prozent gespeichert,
-// um diese bei Abwahl der Checkbox wieder anzeigen zu können.
-const svAnteilForDifferenzdatenSaved = ref(true);
-const gvAnteilForDifferenzdatenSaved = ref(true);
-
 const selectOrDeselectAllVmodel = ref(false);
 const selectOrDeselectAllVerkehrsartenVmodel = ref(false);
 const hoverSelectOrDeselectAll = ref(false);
@@ -650,6 +642,10 @@ const labelSelectOrDeselectAllVerkehrsarten = computed(() => {
     ? "Alles abwählen"
     : "Alles auswählen";
 });
+
+const isDifferenzdatenDarstellung = computed(() => {
+  return chosenOptionsCopy.value.differenzdatenDarstellen && chosenOptionsCopy.value.vergleichszaehlungsId != null
+})
 
 /**
  * Hilfsmethode, um alle Checkboxen der Fahrzeugkategorien aufeinmal
@@ -1000,27 +996,6 @@ function adaptFahrzeugauswahl(
 function isTypeDisabled(type: string): boolean {
   return zaehlstelleUtils.isTypeDisabled(type, activeZaehlung.value);
 }
-
-watch(
-  () => chosenOptionsCopy.value.differenzdatenDarstellen,
-  () => {
-    if (chosenOptionsCopy.value.differenzdatenDarstellen) {
-      // Werte zwischenspeichern und auf false setzen
-      svAnteilForDifferenzdatenSaved.value =
-        chosenOptionsCopy.value.schwerverkehrsanteilProzent;
-      gvAnteilForDifferenzdatenSaved.value =
-        chosenOptionsCopy.value.gueterverkehrsanteilProzent;
-      chosenOptionsCopy.value.schwerverkehrsanteilProzent = false;
-      chosenOptionsCopy.value.gueterverkehrsanteilProzent = false;
-    } else {
-      // Zwischengespeicherte Werte den Optionen zuweisen
-      chosenOptionsCopy.value.schwerverkehrsanteilProzent =
-        svAnteilForDifferenzdatenSaved.value;
-      chosenOptionsCopy.value.gueterverkehrsanteilProzent =
-        gvAnteilForDifferenzdatenSaved.value;
-    }
-  }
-);
 
 watch(
   chosenOptionsCopy,

--- a/frontend/src/store/ZaehlstelleStore.ts
+++ b/frontend/src/store/ZaehlstelleStore.ts
@@ -48,7 +48,9 @@ export const useZaehlstelleStore = defineStore("zaehlstelleStore", () => {
   const getActiveTab = computed(() => activeTab.value);
   const getFilteroptions = computed(() => filteroptions.value);
   const isDifferenzdatenDarstellung = computed(
-    () => filteroptions.value.differenzdatenDarstellen && filteroptions.value.vergleichszaehlungsId
+    () =>
+      filteroptions.value.differenzdatenDarstellen &&
+      filteroptions.value.vergleichszaehlungsId
   );
   const isBlackprintMode = computed(() => filteroptions.value.blackPrintMode);
   const getZeitblock = computed(() => zeitblock.value);

--- a/frontend/src/store/ZaehlstelleStore.ts
+++ b/frontend/src/store/ZaehlstelleStore.ts
@@ -48,7 +48,7 @@ export const useZaehlstelleStore = defineStore("zaehlstelleStore", () => {
   const getActiveTab = computed(() => activeTab.value);
   const getFilteroptions = computed(() => filteroptions.value);
   const isDifferenzdatenDarstellung = computed(
-    () => filteroptions.value.differenzdatenDarstellen
+    () => filteroptions.value.differenzdatenDarstellen && filteroptions.value.vergleichszaehlungsId
   );
   const isBlackprintMode = computed(() => filteroptions.value.blackPrintMode);
   const getZeitblock = computed(() => zeitblock.value);

--- a/frontend/src/util/ZaehlstelleUtils.ts
+++ b/frontend/src/util/ZaehlstelleUtils.ts
@@ -14,22 +14,28 @@ export function useZaehlstelleUtils() {
   }
 
   function hasSelectedVerkehrsarten(options: ZaehlstelleOptionsDTO) {
-
-      // Im Fall der Auswahl von Differenzdatendarstellung muss mind. eine Verkehrsart kein Anteil sein
-      if (options.differenzdatenDarstellen && options.vergleichszaehlungsId != null) {
-        return (options.kraftfahrzeugverkehr ||
+    // Im Fall der Auswahl von Differenzdatendarstellung muss mind. eine Verkehrsart KEIN Anteil sein
+    if (
+      options.differenzdatenDarstellen &&
+      options.vergleichszaehlungsId != null
+    ) {
+      return (
+        options.kraftfahrzeugverkehr ||
         options.schwerverkehr ||
         options.gueterverkehr ||
         options.radverkehr ||
-        options.fussverkehr);
-      }
-      return (options.kraftfahrzeugverkehr ||
+        options.fussverkehr
+      );
+    }
+    return (
+      options.kraftfahrzeugverkehr ||
       options.schwerverkehr ||
       options.gueterverkehr ||
       options.schwerverkehrsanteilProzent ||
       options.gueterverkehrsanteilProzent ||
       options.radverkehr ||
-      options.fussverkehr);
+      options.fussverkehr
+    );
   }
 
   function hasSelectedFahrzeugkategorie(options: ZaehlstelleOptionsDTO) {

--- a/frontend/src/util/ZaehlstelleUtils.ts
+++ b/frontend/src/util/ZaehlstelleUtils.ts
@@ -1,6 +1,8 @@
 import type LadeZaehlungDTO from "@/types/zaehlung/LadeZaehlungDTO";
 import type ZaehlstelleOptionsDTO from "@/types/zaehlung/ZaehlstelleOptionsDTO";
 
+import { isEmpty } from "lodash";
+
 export function useZaehlstelleUtils() {
   /**
    * Überprüft, ob eine Verkehrsart bei der Zählung erfasst wurde.
@@ -17,7 +19,7 @@ export function useZaehlstelleUtils() {
     // Im Fall der Auswahl von Differenzdatendarstellung muss mind. eine Verkehrsart KEIN Anteil sein
     if (
       options.differenzdatenDarstellen &&
-      options.vergleichszaehlungsId != null
+      !isEmpty(options.vergleichszaehlungsId)
     ) {
       return (
         options.kraftfahrzeugverkehr ||

--- a/frontend/src/util/ZaehlstelleUtils.ts
+++ b/frontend/src/util/ZaehlstelleUtils.ts
@@ -14,15 +14,22 @@ export function useZaehlstelleUtils() {
   }
 
   function hasSelectedVerkehrsarten(options: ZaehlstelleOptionsDTO) {
-    return (
-      options.kraftfahrzeugverkehr ||
+
+      // Im Fall der Auswahl von Differenzdatendarstellung muss mind. eine Verkehrsart kein Anteil sein
+      if (options.differenzdatenDarstellen && options.vergleichszaehlungsId != null) {
+        return (options.kraftfahrzeugverkehr ||
+        options.schwerverkehr ||
+        options.gueterverkehr ||
+        options.radverkehr ||
+        options.fussverkehr);
+      }
+      return (options.kraftfahrzeugverkehr ||
       options.schwerverkehr ||
       options.gueterverkehr ||
       options.schwerverkehrsanteilProzent ||
       options.gueterverkehrsanteilProzent ||
       options.radverkehr ||
-      options.fussverkehr
-    );
+      options.fussverkehr);
   }
 
   function hasSelectedFahrzeugkategorie(options: ZaehlstelleOptionsDTO) {


### PR DESCRIPTION
# Description

Anpassung Filtermenü Verkehrsarten Anteilauswahl bei Differenzdatenvergleich

# Issue References

https://jira.muenchen.de/browse/FV-371
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [ ] Acceptance criteria are met
- [ ] Testing is done (unit-tests, DEV-environment)
- [ ] Build/Test workflow has successfully finished
- [ ] Release notes are complemented
- [ ] Documentation is complemented (operator manual, system specification, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved behavior of heavy vehicle and commercial vehicle percentage indicator checkboxes during traffic count comparison analysis (including their hints and display visibility rules).
  * Refined comparison display mode activation so it enables only when both comparison mode is turned on and a valid comparison dataset is selected.
  * Enhanced traffic type selection logic to better handle comparison visualization scenarios, ensuring proportional vs. non-proportional selections are interpreted correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->