### PR TITLE
FV-434 KnotenverkehrForm Qu: Pfeil verrutscht

### DIFF
--- a/frontend/src/components/zaehlstelle/optionsmenue/panels/verkehrsbeziehungen/KnotenverkehrForm.vue
+++ b/frontend/src/components/zaehlstelle/optionsmenue/panels/verkehrsbeziehungen/KnotenverkehrForm.vue
@@ -374,7 +374,7 @@
               <path
                 v-if="isQuerungsverkehrAvailable(7, Himmelsrichtung.SO)"
                 id="node7_crossing_south_east"
-                d="m 591.66231,1099.9989 h 194.44506 v -11.1112 l 38.8883,19.4435 -38.8883,19.4454 v -11.1111 H 591.66231 Z"
+                d="m 575.66231,1099.9989 h 194.44506 v -11.1112 l 38.8883,19.4435 -38.8883,19.4454 v -11.1111 H 575.66231 Z"
                 stroke="none"
                 :style="{ cursor: 'pointer' }"
                 :fill="calculateColorOfQuerungsverkehr(7, Himmelsrichtung.SO)"


### PR DESCRIPTION
# Description

Fixes position of arrow "node7_crossing_south_east".

# Issue References

FV-434
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [x] Acceptance criteria are met
- [x] Testing is done (unit-tests, DEV-environment)
- [x] Build/Test workflow has successfully finished
- [x] Release notes are complemented
- [x] Documentation is complemented (operator manual, system specification, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted a diagram/path element so the affected crossing is displayed in the correct position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->