### PR TITLE
FV-406 BLP Qu: Knotenarme gewellt im PDF-Export

### DIFF
--- a/frontend/src/components/zaehlstelle/ZaehldatenDiagramme.vue
+++ b/frontend/src/components/zaehlstelle/ZaehldatenDiagramme.vue
@@ -400,6 +400,9 @@ watch(belastungsplanSvg, () => {
       canvas.height = dimension;
       const context = canvas.getContext("2d");
       if (context) {
+        // Weißen Hintergrund setzen
+        context.fillStyle = "#ffffff";
+        context.fillRect(0, 0, canvas.width, canvas.height);
         context.drawImage(image, 0, 0, dimension, dimension);
         // Image Asset erstellen und in Variable speichern
         belastungsplanPngBase64.value = canvas.toDataURL("image/jpg");

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanQuSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanQuSvg.vue
@@ -3825,7 +3825,8 @@ watch(
     await nextTick();
 
     emitSvgAsBlob();
-  }
+  },
+  { deep: true, immediate: true }
 );
 
 function isQuBelastungsplan(


### PR DESCRIPTION
# Description

Adds white background to image of BLP Qu to fix wavy knotenarme in pdf export.

# Issue References

FV-406
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [x] Acceptance criteria are met
- [x] Testing is done (unit-tests, DEV-environment)
- [x] Build/Test workflow has successfully finished
- [x] Release notes are complemented
- [x] Documentation is complemented (operator manual, system specification, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Exported chart images now use a white background, preventing transparent or dark-looking areas in generated PNGs and downstream outputs.
  * Chart SVG updates now refresh more reliably when underlying details change, including on initial load and when nested values are edited.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->