### PR TITLE
FV-472 Bugfix: Elemente verrutscht in BLP Messstelle

### DIFF
--- a/frontend/src/components/messstelle/charts/BelastungsplanMessquerschnittCard.vue
+++ b/frontend/src/components/messstelle/charts/BelastungsplanMessquerschnittCard.vue
@@ -375,15 +375,15 @@ function addSumNorthIfNecessary(
       SVG.SVG()
         .line(
           startX.value - 25,
-          startY.value + 80,
+          startY.value + 800,
           startX.value - 25,
-          startY.value + (1080 - (3 - numberOfChosenFahrzeugOptions.value) * 65)
+          startY.value + 800 + numberOfChosenFahrzeugOptions.value * 75
         )
         .stroke({ width: 1, color: "black" })
     );
     addTextSouthSide(
       startX.value - 20,
-      startY.value + 923,
+      startY.value + 873,
       sumMqKfz,
       sumMqGv,
       sumMqSv,


### PR DESCRIPTION
# Description

Adjusts the position of sum north in BLP Messstelle.

# Issue References

FV-472
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [x] Acceptance criteria are met
- [x] Testing is done (unit-tests, DEV-environment)
- [x] Build/Test workflow has successfully finished
- [x] Release notes are complemented
- [x] Documentation is complemented (operator manual, system specification, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the layout of the “sum” section in Belastungsplan charts.
  * Adjusted separator and label positioning to ensure consistent alignment across different vehicle-option selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->