### PR TITLE
FV-486 BLP Belastungsbänder zu breit bei QjS im Vergleich zu bestehenden Zählarten

### DIFF
--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
@@ -645,7 +645,7 @@
                 stroke-width: 3.26332;
                 stroke-dasharray: none;
               "
-              d="m 133.56306,623.4872453 h 80.44096 v 1.0263 h -80.44096 z"
+              d="m 133.56306,626.5 h 80.44096 v 1.0263 h -80.44096 z"
               id="arrows_1_and_2_sum_line"
             />
             <text
@@ -672,12 +672,12 @@
                   stroke-width: 43.9644;
                 `"
               x="215.26794"
-              y="643.40129687"
+              y="647.69934"
             >
               <tspan
                 id="arrows_1_and_2_sum_tspan"
                 x="215.26794"
-                y="643.40129687"
+                y="647.69934"
               >
                 {{ sumArrowsOneTwo }}
               </tspan>
@@ -796,7 +796,7 @@
             </g>
             <path
               style="fill: #000000; fill-opacity: 1; stroke-width: 13.4005"
-              d="m 1186.6029,862.50248 h 87.5595 v 0.55173 h -87.5595 z"
+              d="m 1186.6029,864.49999 h 87.5595 v 1.0263 h -87.5595 z"
               id="arrows_3_and_4_sum_line"
             />
             <text
@@ -823,12 +823,12 @@
                   stroke-width: 43.9644;
                 `"
               x="1274.8474"
-              y="882.1888042"
+              y="885.69934"
             >
               <tspan
                 id="arrows_3_and_4_sum_tspan"
                 x="1274.8474"
-                y="882.1888042"
+                y="885.69934"
               >
                 {{ sumArrowsThreeFour }}
               </tspan>

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
@@ -1007,10 +1007,10 @@ const transformArrowFour = computed(() =>
 );
 
 // --- Pfad-Daten
-const dArrowOne = "m 245,567 v -28 h 909.4546 v 27.998 z";
-const dArrowTwo = "m 245.31124,623 v -28 h 909.68866 v 27.997 z";
-const dArrowThree = "m 245,804.99999 v -28 h 910.1007 v 27.997 z";
-const dArrowFour = "m 244.89933,860.99999 v -28 H 1155 v 27.997 z";
+const dArrowOne = `m 245,567 v -${belastungsplanMethods.maxlineWidth} h 909.4546 v ${belastungsplanMethods.maxlineWidth} z`;
+const dArrowTwo = `m 245.31124,623 v -${belastungsplanMethods.maxlineWidth} h 909.68866 v ${belastungsplanMethods.maxlineWidth} z`;
+const dArrowThree = `m 245,804.99999 v -${belastungsplanMethods.maxlineWidth} h 910.1007 v ${belastungsplanMethods.maxlineWidth} z`;
+const dArrowFour = `m 244.89933,860.99999 v -${belastungsplanMethods.maxlineWidth} H 1155 v ${belastungsplanMethods.maxlineWidth} z`;
 
 const activeZaehlung = computed<LadeZaehlungDTO>(() => {
   return zaehlstelleStore.getAktiveZaehlung;

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
@@ -541,12 +541,12 @@
                 style="
                   fill: none;
                   stroke: #000000;
-                  stroke-width: 2.08902;
+                  stroke-width: 1.75545;
                   stroke-dasharray: none;
                   stroke-opacity: 1;
                 "
                 id="arrow1_tip"
-                d="m 221.73348,553.05942 19.31149,-25.58133 0.0167,51.09625 z"
+                d="m 221.73348,557.05942 19.31149,-18.45207 0.0167,36.84587 z"
               />
               <text
                 xml:space="preserve"
@@ -572,12 +572,12 @@
                   stroke-width: 43.9482;
                 `"
                 x="215.24681"
-                y="562.0257"
+                y="563.9740875"
               >
                 <tspan
                   id="arrow1_zaehlwert_tspan"
                   x="215.24681"
-                  y="562.0257"
+                  y="563.9740875"
                 >
                   {{ zaehlwertArrowOne }}
                 </tspan>
@@ -601,7 +601,7 @@
                   stroke-opacity: 1;
                 "
                 id="arrow2_tip"
-                d="m 1178.1206,609.06771 -18.7975,-22.45207 -0.017,44.84587 z"
+                d="m 1178.1206,613.06771 -19.31149,-18.45207 -0.0169,36.84587 z"
               />
               <text
                 xml:space="preserve"
@@ -627,12 +627,12 @@
                   stroke-width: 43.9482;
                 `"
                 x="215.83165"
-                y="615.81903"
+                y="619.9740821"
               >
                 <tspan
                   id="arrow2_zaehlwert_tspan"
                   x="215.83165"
-                  y="615.81903"
+                  y="619.9740821"
                 >
                   {{ zaehlwertArrowTwo }}
                 </tspan>
@@ -645,7 +645,7 @@
                 stroke-width: 3.26332;
                 stroke-dasharray: none;
               "
-              d="m 133.56306,621.30263 h 80.44096 v 1.0263 h -80.44096 z"
+              d="m 133.56306,623.4872453 h 80.44096 v 1.0263 h -80.44096 z"
               id="arrows_1_and_2_sum_line"
             />
             <text
@@ -672,12 +672,12 @@
                   stroke-width: 43.9644;
                 `"
               x="215.26794"
-              y="642.70013"
+              y="643.40129687"
             >
               <tspan
                 id="arrows_1_and_2_sum_tspan"
                 x="215.26794"
-                y="642.70013"
+                y="643.40129687"
               >
                 {{ sumArrowsOneTwo }}
               </tspan>
@@ -702,7 +702,7 @@
                   stroke-opacity: 1;
                 "
                 id="arrow3_tip"
-                d="m 221.49329,791.09394 19.39305,-22.32164 0.0169,44.58532 z"
+                d="m 221.49329,795.09394 19.31149,-18.45207 0.0169,36.84587 z"
               />
               <text
                 xml:space="preserve"
@@ -728,12 +728,12 @@
                   stroke-width: 43.9482;
                 `"
                 x="1274.4691"
-                y="799.2951"
+                y="801.974045"
               >
                 <tspan
                   id="arrow3_zaehlwert_tspan"
                   x="1274.4691"
-                  y="799.2951"
+                  y="801.974045"
                 >
                   {{ zaehlwertArrowThree }}
                 </tspan>
@@ -757,7 +757,7 @@
                   stroke-opacity: 1;
                 "
                 id="arrow4_tip"
-                d="m 1178.1774,846.90543 -18.6954,-22.33904 -0.017,44.62008 z"
+                d="m 1178.1774,850.90543 -19.31149,-18.45207 -0.0169,36.84587 z"
               />
               <text
                 xml:space="preserve"
@@ -782,13 +782,13 @@
                   fill-opacity: 1;
                   stroke-width: 43.9482;
                 `"
-                x="1273.3658"
-                y="855.68152"
+                x="1274.4691"
+                y="857.974051"
               >
                 <tspan
                   id="arrow4_zaehlwert_tspan"
-                  x="1273.3658"
-                  y="855.68152"
+                  x="1274.4691"
+                  y="857.974051"
                 >
                   {{ zaehlwertArrowFour }}
                 </tspan>
@@ -823,12 +823,12 @@
                   stroke-width: 43.9644;
                 `"
               x="1274.8474"
-              y="884.09052"
+              y="882.1888042"
             >
               <tspan
                 id="arrows_3_and_4_sum_tspan"
                 x="1274.8474"
-                y="884.09052"
+                y="882.1888042"
               >
                 {{ sumArrowsThreeFour }}
               </tspan>

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
@@ -527,8 +527,14 @@
           </text>
         </g>
         <g id="arrows">
-          <g v-if="isCountedArrowOne || isCountedArrowTwo" id="arrows_1_and_2">
-            <g v-if="isCountedArrowOne" id="arrow1">
+          <g
+            v-if="isCountedArrowOne || isCountedArrowTwo"
+            id="arrows_1_and_2"
+          >
+            <g
+              v-if="isCountedArrowOne"
+              id="arrow1"
+            >
               <path
                 style="stroke-width: 40.1656"
                 :d="dArrowOne"
@@ -583,7 +589,10 @@
                 </tspan>
               </text>
             </g>
-            <g v-if="isCountedArrowTwo" id="arrow2">
+            <g
+              v-if="isCountedArrowTwo"
+              id="arrow2"
+            >
               <path
                 style="stroke-width: 40.1708"
                 :d="dArrowTwo"
@@ -683,8 +692,14 @@
               </tspan>
             </text>
           </g>
-          <g v-if="isCountedArrowThree || isCountedArrowFour" id="arrows_3_and_4">
-            <g v-if="isCountedArrowThree" id="arrow3">
+          <g
+            v-if="isCountedArrowThree || isCountedArrowFour"
+            id="arrows_3_and_4"
+          >
+            <g
+              v-if="isCountedArrowThree"
+              id="arrow3"
+            >
               <path
                 style="stroke-width: 40.1798"
                 :d="dArrowThree"
@@ -739,7 +754,10 @@
                 </tspan>
               </text>
             </g>
-            <g v-if="isCountedArrowFour" id="arrow4">
+            <g
+              v-if="isCountedArrowFour"
+              id="arrow4"
+            >
               <path
                 style="stroke-width: 40.1798"
                 :d="dArrowFour"
@@ -1056,29 +1074,29 @@ const isSelectedArrowFour = computed(() => {
 
 const isCountedArrowOne = computed(() => {
   return qjs.hasAnyArrowPatternIn(
-      activeZaehlung.value.verkehrsbeziehungen,
-      qjs.patternsArrowOne
+    activeZaehlung.value.verkehrsbeziehungen,
+    qjs.patternsArrowOne
   );
 });
 
 const isCountedArrowTwo = computed(() => {
   return qjs.hasAnyArrowPatternIn(
-      activeZaehlung.value.verkehrsbeziehungen,
-      qjs.patternsArrowTwo
+    activeZaehlung.value.verkehrsbeziehungen,
+    qjs.patternsArrowTwo
   );
 });
 
 const isCountedArrowThree = computed(() => {
   return qjs.hasAnyArrowPatternIn(
-      activeZaehlung.value.verkehrsbeziehungen,
-      qjs.patternsArrowThree
+    activeZaehlung.value.verkehrsbeziehungen,
+    qjs.patternsArrowThree
   );
 });
 
 const isCountedArrowFour = computed(() => {
   return qjs.hasAnyArrowPatternIn(
-      activeZaehlung.value.verkehrsbeziehungen,
-      qjs.patternsArrowFour
+    activeZaehlung.value.verkehrsbeziehungen,
+    qjs.patternsArrowFour
   );
 });
 


### PR DESCRIPTION
# Description

- Set maximum width of arrows (belastungsbänder) to width of arrows of zaehlart Q
- Adjust position of arrow tips and zaehlwert numbers to match with center of arrows

# Issue References

FV-486
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [x] Acceptance criteria are met
- [x] Testing is done (unit-tests, DEV-environment)
- [x] Build/Test workflow has successfully finished
- [x] Release notes are complemented
- [x] Documentation is complemented (operator manual, system specification, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the visual alignment and proportions of arrow indicators in Belastungsplan charts.
  * Updated arrow tips, labels, sum bars, and value positioning for clearer presentation.
  * Adjusted arrow rendering to respond more consistently to configured line-width settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->