### PR TITLE
FV-427 Fehler bei 2x4h Zählung mit Filterauswahl nur SVP und GVP

### DIFF
--- a/frontend/src/components/zaehlstelle/charts/HeatmapChart.vue
+++ b/frontend/src/components/zaehlstelle/charts/HeatmapChart.vue
@@ -71,10 +71,7 @@ function formatYAxisLabel(value: any): string {
 function checkTwoChartsNeeded(
   zaehldatenHeatmap: LadeZaehldatenHeatmapDTO
 ): boolean {
-  return (
-    zaehldatenHeatmap.xaxisDataSecondChart !== null &&
-    zaehldatenHeatmap.seriesEntriesSecondChart !== null
-  );
+  return zaehldatenHeatmap.xaxisDataSecondChart !== null;
 }
 
 function resetData(): void {


### PR DESCRIPTION
# Description

Splits heatmap diagram also when no y axis values for the second chart are present. This is the case for 2x4h countings with only GV% and/or SV% selected.

# Issue References

FV-427
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [x] Acceptance criteria are met
- [x] Testing is done (unit-tests, DEV-environment)
- [x] Build/Test workflow has successfully finished
- [x] Release notes are complemented
- [x] Documentation is complemented (operator manual, system specification, etc.)