### PR TITLE
FV-491 Filter Verkehrsartenauswahl Ergänzung

### DIFF
--- a/frontend/src/components/zaehlstelle/optionsmenue/OptionsmenueZaehlstelle.vue
+++ b/frontend/src/components/zaehlstelle/optionsmenue/OptionsmenueZaehlstelle.vue
@@ -140,6 +140,29 @@ const isTeilzaehlungFussverkehr = computed(() => {
 });
 
 /**
+ * Gibt {@link true} zurück, wenn für die Zählung NUR die Verkehrsart FUSS beauftragt wurde.
+ */
+function isOnlyVerkehrsartFuss() {
+  return (
+    activeZaehlung.value.kategorien.length === 1 &&
+    activeZaehlung.value.kategorien.includes(Fahrzeug.FUSS)
+  );
+}
+
+/**
+ * Gibt an, ob die Verkehrsart FUSS im Filtermenü vorbelegt sein soll.
+ */
+function isFussPreselected() {
+  // FUSS soll nur bei Zählarten FjS, Qu, QjS aktiviert sein oder bei
+  // anderen Zählarten, wenn als einzige Verkehrsart FUSS beauftragt wurde
+  return (
+    [Zaehlart.FJS, Zaehlart.QU, Zaehlart.QJS].includes(
+      activeZaehlung.value.zaehlart as Zaehlart
+    ) || isOnlyVerkehrsartFuss()
+  );
+}
+
+/**
  * Setzt die Default-Einstellungen für das Optionsmenü je nach Zählung
  */
 function setDefaultOptionsForZaehlung() {
@@ -222,15 +245,10 @@ function setDefaultOptionsForZaehlung() {
           Zaehlart.FJS,
           Zaehlart.QU,
           Zaehlart.QJS,
-        ].includes(activeZaehlung.value.zaehlart);
+        ].includes(activeZaehlung.value.zaehlart as Zaehlart);
         break;
       case Fahrzeug.FUSS:
-        // Fuss soll nur bei Zählarten FjS, Qu, QjS aktiviert sein
-        optionsCopy.fussverkehr = [
-          Zaehlart.FJS,
-          Zaehlart.QU,
-          Zaehlart.QJS,
-        ].includes(activeZaehlung.value.zaehlart);
+        optionsCopy.fussverkehr = isFussPreselected();
         break;
     }
   });

--- a/frontend/src/components/zaehlstelle/optionsmenue/OptionsmenueZaehlstelle.vue
+++ b/frontend/src/components/zaehlstelle/optionsmenue/OptionsmenueZaehlstelle.vue
@@ -150,6 +150,17 @@ function isOnlyVerkehrsartFuss() {
 }
 
 /**
+ * Gibt {@link true} zurück, wenn für die Zählung NUR die Verkehrsart RAD beauftragt wurde.
+ */
+function isOnlyVerkehrsartRad() {
+  return (
+    activeZaehlung.value.kategorien.length === 2 &&
+    activeZaehlung.value.kategorien.includes(Fahrzeug.RAD) &&
+    activeZaehlung.value.kategorien.includes(Fahrzeug.PKW_EINHEIT)
+  );
+}
+
+/**
  * Gibt an, ob die Verkehrsart FUSS im Filtermenü vorbelegt sein soll.
  */
 function isFussPreselected() {
@@ -159,6 +170,19 @@ function isFussPreselected() {
     [Zaehlart.FJS, Zaehlart.QU, Zaehlart.QJS].includes(
       activeZaehlung.value.zaehlart as Zaehlart
     ) || isOnlyVerkehrsartFuss()
+  );
+}
+
+/**
+ * Gibt an, ob die Verkehrsart RAD im Filtermenü vorbelegt sein soll.
+ */
+function isRadPreselected() {
+  // RAD soll nur bei bestimmten Zählarten aktiviert sein oder bei anderen
+  // Zählarten, wenn als einzige Verkehrsart RAD beauftragt wurde
+  return (
+    [Zaehlart.R, Zaehlart.QR, Zaehlart.FJS, Zaehlart.QU, Zaehlart.QJS].includes(
+      activeZaehlung.value.zaehlart as Zaehlart
+    ) || isOnlyVerkehrsartRad()
   );
 }
 
@@ -238,14 +262,7 @@ function setDefaultOptionsForZaehlung() {
         optionsCopy.gueterverkehrsanteilProzent = true;
         break;
       case Fahrzeug.RAD:
-        // Rad soll nur bei bestimmten Zählarten aktiviert sein
-        optionsCopy.radverkehr = [
-          Zaehlart.R,
-          Zaehlart.QR,
-          Zaehlart.FJS,
-          Zaehlart.QU,
-          Zaehlart.QJS,
-        ].includes(activeZaehlung.value.zaehlart as Zaehlart);
+        optionsCopy.radverkehr = isRadPreselected();
         break;
       case Fahrzeug.FUSS:
         optionsCopy.fussverkehr = isFussPreselected();

--- a/frontend/src/components/zaehlstelle/optionsmenue/OptionsmenueZaehlstelle.vue
+++ b/frontend/src/components/zaehlstelle/optionsmenue/OptionsmenueZaehlstelle.vue
@@ -177,7 +177,8 @@ const areOnlyVerkehrsartenRadAndFuss = computed(() => {
  */
 const isFussPreselected = computed(() => {
   // FUSS soll nur bei Zählarten FjS, Qu, QjS aktiviert sein oder bei
-  // anderen Zählarten, wenn als einzige Verkehrsart FUSS beauftragt wurde
+  // anderen Zählarten, wenn als einzige Verkehrsart NUR FUSS oder NUR RAD
+  // UND FUSS beauftragt wurde
   return (
     [Zaehlart.FJS, Zaehlart.QU, Zaehlart.QJS].includes(
       activeZaehlung.value.zaehlart as Zaehlart
@@ -192,7 +193,8 @@ const isFussPreselected = computed(() => {
  */
 const isRadPreselected = computed(() => {
   // RAD soll nur bei bestimmten Zählarten aktiviert sein oder bei anderen
-  // Zählarten, wenn als einzige Verkehrsart RAD beauftragt wurde
+  // Zählarten, wenn als einzige Verkehrsart NUR RAD oder NUR RAD UND FUSS
+  // beauftragt wurde
   return (
     [Zaehlart.R, Zaehlart.QR, Zaehlart.FJS, Zaehlart.QU, Zaehlart.QJS].includes(
       activeZaehlung.value.zaehlart as Zaehlart

--- a/frontend/src/components/zaehlstelle/optionsmenue/OptionsmenueZaehlstelle.vue
+++ b/frontend/src/components/zaehlstelle/optionsmenue/OptionsmenueZaehlstelle.vue
@@ -140,51 +140,51 @@ const isTeilzaehlungFussverkehr = computed(() => {
 });
 
 /**
- * Gibt {@link true} zurück, wenn für die Zählung NUR die Verkehrsart FUSS beauftragt wurde.
+ * Ist {@link true}, wenn für die Zählung NUR die Verkehrsart FUSS beauftragt wurde.
  */
-function isOnlyVerkehrsartFuss() {
+const isOnlyVerkehrsartFuss = computed(() => {
   return (
     activeZaehlung.value.kategorien.length === 1 &&
     activeZaehlung.value.kategorien.includes(Fahrzeug.FUSS)
   );
-}
+});
 
 /**
- * Gibt {@link true} zurück, wenn für die Zählung NUR die Verkehrsart RAD beauftragt wurde.
+ * Ist {@link true}, wenn für die Zählung NUR die Verkehrsart RAD beauftragt wurde.
  */
-function isOnlyVerkehrsartRad() {
+const isOnlyVerkehrsartRad = computed(() => {
   return (
     activeZaehlung.value.kategorien.length === 2 &&
     activeZaehlung.value.kategorien.includes(Fahrzeug.RAD) &&
     activeZaehlung.value.kategorien.includes(Fahrzeug.PKW_EINHEIT)
   );
-}
+});
 
 /**
  * Gibt an, ob die Verkehrsart FUSS im Filtermenü vorbelegt sein soll.
  */
-function isFussPreselected() {
+const isFussPreselected = computed(() => {
   // FUSS soll nur bei Zählarten FjS, Qu, QjS aktiviert sein oder bei
   // anderen Zählarten, wenn als einzige Verkehrsart FUSS beauftragt wurde
   return (
     [Zaehlart.FJS, Zaehlart.QU, Zaehlart.QJS].includes(
       activeZaehlung.value.zaehlart as Zaehlart
-    ) || isOnlyVerkehrsartFuss()
+    ) || isOnlyVerkehrsartFuss.value
   );
-}
+});
 
 /**
  * Gibt an, ob die Verkehrsart RAD im Filtermenü vorbelegt sein soll.
  */
-function isRadPreselected() {
+const isRadPreselected = computed(() => {
   // RAD soll nur bei bestimmten Zählarten aktiviert sein oder bei anderen
   // Zählarten, wenn als einzige Verkehrsart RAD beauftragt wurde
   return (
     [Zaehlart.R, Zaehlart.QR, Zaehlart.FJS, Zaehlart.QU, Zaehlart.QJS].includes(
       activeZaehlung.value.zaehlart as Zaehlart
-    ) || isOnlyVerkehrsartRad()
+    ) || isOnlyVerkehrsartRad.value
   );
-}
+});
 
 /**
  * Setzt die Default-Einstellungen für das Optionsmenü je nach Zählung
@@ -262,10 +262,10 @@ function setDefaultOptionsForZaehlung() {
         optionsCopy.gueterverkehrsanteilProzent = true;
         break;
       case Fahrzeug.RAD:
-        optionsCopy.radverkehr = isRadPreselected();
+        optionsCopy.radverkehr = isRadPreselected.value;
         break;
       case Fahrzeug.FUSS:
-        optionsCopy.fussverkehr = isFussPreselected();
+        optionsCopy.fussverkehr = isFussPreselected.value;
         break;
     }
   });

--- a/frontend/src/components/zaehlstelle/optionsmenue/OptionsmenueZaehlstelle.vue
+++ b/frontend/src/components/zaehlstelle/optionsmenue/OptionsmenueZaehlstelle.vue
@@ -161,6 +161,18 @@ const isOnlyVerkehrsartRad = computed(() => {
 });
 
 /**
+ * Ist {@link true}, wenn für die Zählung NUR die Verkehrsarten RAD und FUSS beauftragt wurden.
+ */
+const areOnlyVerkehrsartenRadAndFuss = computed(() => {
+  return (
+    activeZaehlung.value.kategorien.length === 3 &&
+    activeZaehlung.value.kategorien.includes(Fahrzeug.RAD) &&
+    activeZaehlung.value.kategorien.includes(Fahrzeug.PKW_EINHEIT) &&
+    activeZaehlung.value.kategorien.includes(Fahrzeug.FUSS)
+  );
+});
+
+/**
  * Gibt an, ob die Verkehrsart FUSS im Filtermenü vorbelegt sein soll.
  */
 const isFussPreselected = computed(() => {
@@ -169,7 +181,9 @@ const isFussPreselected = computed(() => {
   return (
     [Zaehlart.FJS, Zaehlart.QU, Zaehlart.QJS].includes(
       activeZaehlung.value.zaehlart as Zaehlart
-    ) || isOnlyVerkehrsartFuss.value
+    ) ||
+    isOnlyVerkehrsartFuss.value ||
+    areOnlyVerkehrsartenRadAndFuss.value
   );
 });
 
@@ -182,7 +196,9 @@ const isRadPreselected = computed(() => {
   return (
     [Zaehlart.R, Zaehlart.QR, Zaehlart.FJS, Zaehlart.QU, Zaehlart.QJS].includes(
       activeZaehlung.value.zaehlart as Zaehlart
-    ) || isOnlyVerkehrsartRad.value
+    ) ||
+    isOnlyVerkehrsartRad.value ||
+    areOnlyVerkehrsartenRadAndFuss.value
   );
 });
 


### PR DESCRIPTION
# Description

Adjusts preselection of verkehrsarten rad and fuss in filter options.

# Issue References

FV-491
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [x] Acceptance criteria are met
- [x] Testing is done (unit-tests, DEV-environment)
- [x] Build/Test workflow has successfully finished
- [x] Release notes are complemented
- [x] Documentation is complemented (operator manual, system specification, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the default selection of cycling and pedestrian traffic filters in the counting options menu.
  * Filter preselection now accurately reflects combined counting categories and cases limited to cycling or pedestrian traffic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->