### PR TITLE
FV-550 Bugfix: Fehlerhaftes Verhalten bei Summe aller Verkehrsarten

### DIFF
--- a/frontend/src/components/zaehlstelle/optionsmenue/panels/DarstellungsoptionenPanel.vue
+++ b/frontend/src/components/zaehlstelle/optionsmenue/panels/DarstellungsoptionenPanel.vue
@@ -254,7 +254,7 @@
             density="compact"
             @mouseover="hoverZeitreiheGesamt = true"
             @mouseleave="hoverZeitreiheGesamt = false"
-            :disabled="isTypeKfzDisabled()"
+            :disabled="isCheckboxZeitreiheGesamtDisabled"
           />
         </v-col>
         <v-spacer />
@@ -385,6 +385,22 @@ const helpTextZeitreihe = computed(() => {
   return "";
 });
 
+const isCheckboxZeitreiheGesamtDisabled = computed(() => {
+  return isTypeKfzDisabled() || isOnlyFussFiltered.value;
+});
+
+const isOnlyFussFiltered = computed(() => {
+  return (
+    !chosenOptionsCopy.value.kraftfahrzeugverkehr &&
+    !chosenOptionsCopy.value.gueterverkehr &&
+    !chosenOptionsCopy.value.schwerverkehr &&
+    !chosenOptionsCopy.value.gueterverkehrsanteilProzent &&
+    !chosenOptionsCopy.value.schwerverkehrsanteilProzent &&
+    !chosenOptionsCopy.value.radverkehr &&
+    chosenOptionsCopy.value.fussverkehr
+  );
+});
+
 function isTypeKfzDisabled(): boolean {
   return isTypeDisabled("KFZ");
 }
@@ -436,6 +452,15 @@ watch(sizeBelastungsplan, () => {
 watch(sizeBelastungsplanSvg, (newSize: number) => {
   sizeBelastungsplan.value = newSize;
 });
+
+watch(
+  () => isCheckboxZeitreiheGesamtDisabled.value,
+  () => {
+    if (isCheckboxZeitreiheGesamtDisabled.value) {
+      chosenOptionsCopy.value.zeitreiheGesamt = false;
+    }
+  }
+);
 
 watch(
   () => activeZaehlung.value,


### PR DESCRIPTION
# Description

The checkbox "Summe aller Verkehrsarten anzeigen" is now disabled and deactivated when only fuss is selected in filter menu. Previously the sum of kfz and rad was shown in zeitreihe, although only fuss was selected.

# Issue References

FV-550
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [x] Acceptance criteria are met
- [x] Testing is done (unit-tests, DEV-environment)
- [x] Build/Test workflow has successfully finished
- [x] Release notes are complemented
- [x] Documentation is complemented (operator manual, system specification, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled the “Sum of all traffic types” option when vehicle data is unavailable or only pedestrian traffic is selected.
  * Automatically clears the option when it becomes unavailable, preventing invalid chart selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->