### PR TITLE
FV-568 Bugfix: Tabelle zu PDF-Report hinzufügen nicht gleich Listenausgabe bei "nicht-24h-Zählung"

### DIFF
--- a/frontend/src/components/zaehlstelle/optionsmenue/OptionsmenueZaehlstelle.vue
+++ b/frontend/src/components/zaehlstelle/optionsmenue/OptionsmenueZaehlstelle.vue
@@ -77,7 +77,7 @@
 import type LadeZaehlungDTO from "@/types/zaehlung/LadeZaehlungDTO";
 import type ZaehlstelleOptionsDTO from "@/types/zaehlung/ZaehlstelleOptionsDTO";
 
-import { head, isEmpty, isNil } from "lodash";
+import { isEmpty } from "lodash";
 import { computed, ref, watch } from "vue";
 import { useDisplay } from "vuetify";
 
@@ -210,6 +210,8 @@ const isRadPreselected = computed(() => {
 function setDefaultOptionsForZaehlung() {
   const optionsCopy = {} as ZaehlstelleOptionsDTO;
   Object.assign(optionsCopy, options.value);
+
+  optionsCopy.zaehldauer = activeZaehlung.value.zaehldauer;
 
   if (isTeilzaehlungFussverkehr.value) {
     optionsCopy.zeitauswahl = Zeitauswahl.BLOCK;


### PR DESCRIPTION
# Description

Sets zaehldauer also in options in order to correctly extract it from options in backend during generation of pdf report and show "Tageswert" in listenausgabe of pdf report.

# Issue References

FV-568
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [x] Acceptance criteria are met
- [x] Testing is done (unit-tests, DEV-environment)
- [x] Build/Test workflow has successfully finished
- [x] Release notes are complemented
- [x] Documentation is complemented (operator manual, system specification, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved option initialization by ensuring the active count’s duration is correctly reflected in the options menu.
* **Chores**
  * Removed unused internal code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->