### PR TITLE
FV-583 Bugfix: Maximale Breite von BLP-Band zu breit, wenn nur GV+SV ausgewählt ist

### DIFF
--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanKreuzungSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanKreuzungSvg.vue
@@ -669,19 +669,18 @@ function calcVerkehrsbeziehung(data: LadeBelastungsplanDTO) {
             knotenarmVon.anzahlVonVerkehrsbeziehungen
           );
         // den höchsten und niedrigsten Wert einer Verkehrsbeziehung ermitteln
-        // (gilt hier nur der KFZ Verkehr?)
         if (
-          belastungsplanMethods.positiveNumber(data.value1.values[v][n]) >
+          belastungsplanVerkehrsbeziehung.total >
           highestVerkehrsbeziehungsValue.value
         )
           highestVerkehrsbeziehungsValue.value =
-            belastungsplanMethods.positiveNumber(data.value1.values[v][n]);
+            belastungsplanVerkehrsbeziehung.total;
         if (
-          belastungsplanMethods.positiveNumber(data.value1.values[v][n]) <
+          belastungsplanVerkehrsbeziehung.total <
           lowestVerkehrsbeziehungsValue.value
         )
           lowestVerkehrsbeziehungsValue.value =
-            belastungsplanMethods.positiveNumber(data.value1.values[v][n]);
+            belastungsplanVerkehrsbeziehung.total;
         // Verkehrsbeziehungstyp wird gesetzt um später die Position der Linien berrechnen zu können
         knotenarmVon.addVonVerkehrsbeziehungsType(
           belastungsplanVerkehrsbeziehung.verkehrsbeziehungsTyp

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanKreuzungSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanKreuzungSvg.vue
@@ -670,17 +670,23 @@ function calcVerkehrsbeziehung(data: LadeBelastungsplanDTO) {
           );
         // den höchsten und niedrigsten Wert einer Verkehrsbeziehung ermitteln
         if (
-          belastungsplanVerkehrsbeziehung.total >
-          highestVerkehrsbeziehungsValue.value
+          belastungsplanMethods.positiveNumber(
+            belastungsplanVerkehrsbeziehung.total
+          ) > highestVerkehrsbeziehungsValue.value
         )
           highestVerkehrsbeziehungsValue.value =
-            belastungsplanVerkehrsbeziehung.total;
+            belastungsplanMethods.positiveNumber(
+              belastungsplanVerkehrsbeziehung.total
+            );
         if (
-          belastungsplanVerkehrsbeziehung.total <
-          lowestVerkehrsbeziehungsValue.value
+          belastungsplanMethods.positiveNumber(
+            belastungsplanVerkehrsbeziehung.total
+          ) < lowestVerkehrsbeziehungsValue.value
         )
           lowestVerkehrsbeziehungsValue.value =
-            belastungsplanVerkehrsbeziehung.total;
+            belastungsplanMethods.positiveNumber(
+              belastungsplanVerkehrsbeziehung.total
+            );
         // Verkehrsbeziehungstyp wird gesetzt um später die Position der Linien berrechnen zu können
         knotenarmVon.addVonVerkehrsbeziehungsType(
           belastungsplanVerkehrsbeziehung.verkehrsbeziehungsTyp


### PR DESCRIPTION
# Description

Changed determination of highestVerkehrsbeziehungsValue to calculate correct width.

# Issue References

FV-583
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [x] Acceptance criteria are met
- [x] Testing is done (unit-tests, DEV-environment)
- [x] Build/Test workflow has successfully finished
- [x] Release notes are complemented
- [x] Documentation is complemented (operator manual, system specification, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved traffic relationship calculations in intersection load charts.
  * Minimum and maximum values now accurately reflect each relationship’s total traffic volume.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->