### PR TITLE
FV-584 Datenportal Schwarz-Weiß Druckausgabe für neue Zählarten

### DIFF
--- a/frontend/src/components/messstelle/charts/BelastungsplanMessquerschnittCard.vue
+++ b/frontend/src/components/messstelle/charts/BelastungsplanMessquerschnittCard.vue
@@ -23,6 +23,7 @@ import { zeitblockInfo } from "@/types/enum/Zeitblock";
 import { zeitblockStuendlichInfo } from "@/types/enum/ZeitblockStuendlich";
 import { belastungsplanAnzeigeUtils } from "@/util/BelastungsplanAnzeigeUtils";
 import { useDateUtils } from "@/util/DateUtils";
+import { BelastungsplanConstants } from "@/components/zaehlstelle/charts/BelastungsplanConstants";
 
 interface Props {
   belastungsplanData: BelastungsplanMessquerschnitteDTO;
@@ -851,7 +852,7 @@ function storeImageForPrinting() {
 function getLineColor(mqId: string, direction: string) {
   if (chosenOptionsCopy.value.messquerschnittIds.includes(mqId)) {
     return chosenOptionsCopy.value.blackPrintMode
-      ? "#000000"
+      ? BelastungsplanConstants.blackPrintColor
       : farben.get(direction);
   } else {
     return "#E0E0E0";

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanConstants.ts
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanConstants.ts
@@ -18,6 +18,7 @@ export const BelastungsplanConstants = {
   gleichValueColor: "#000000",
   inaktivColor: "#E0E0E0",
   legendColor: "#757575",
+  blackPrintColor: "#000000",
 
   // kleinstmögliche Skalierung eines Pfeils, damit er überhaupt angezeigt wird
   minimum_arrow_scale: 0.05,

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanFjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanFjsSvg.vue
@@ -5837,8 +5837,10 @@ function setColor(
       strassenseite,
       richtung
     )
-      ? (BelastungsplanConstants.farben.get(node) ??
-        BelastungsplanConstants.inaktivColor)
+      ? zaehlstelleStore.isBlackprintMode
+        ? "#000000"
+        : (BelastungsplanConstants.farben.get(node) ??
+          BelastungsplanConstants.inaktivColor)
       : BelastungsplanConstants.inaktivColor
   );
 }

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanFjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanFjsSvg.vue
@@ -5875,6 +5875,7 @@ watch(
     () => activeZaehlung.value.knotenarme,
     () => optionen.value.zeitauswahl,
     () => optionen.value.chosenLaengsverkehre,
+    () => zaehlstelleStore.isBlackprintMode,
   ],
   async () => {
     setStreetnameNodes();

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanFjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanFjsSvg.vue
@@ -5838,7 +5838,7 @@ function setColor(
       richtung
     )
       ? zaehlstelleStore.isBlackprintMode
-        ? "#000000"
+        ? BelastungsplanConstants.blackPrintColor
         : (BelastungsplanConstants.farben.get(node) ??
           BelastungsplanConstants.inaktivColor)
       : BelastungsplanConstants.inaktivColor

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanMethods.ts
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanMethods.ts
@@ -1328,7 +1328,7 @@ export function useBelastungsplanMethods() {
     // Wenn der schwarz weiß Modus angeschaltet ist, dann werden alle aktiven Verkehrsbeziehungen
     // schwarz gedruckt.
     if (isBlackPrintMode.value) {
-      return "#000000";
+      return BelastungsplanConstants.blackPrintColor;
     }
 
     // Wenn die Geometrieauswahl im Belastungsplan angezeigt werden soll ("Zeige von Knotenarm, nach Knotenarm"),

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
@@ -1361,6 +1361,7 @@ watch(
     () => optionen.value.chosenVerkehrsbeziehungen,
     () => optionen.value.zeitauswahl,
     () => zaehlstelleStore.getStartEndeUhrzeitIntervalls,
+    () => zaehlstelleStore.isBlackprintMode,
   ],
   async () => {
     firstStreetname.value = strassennameUtils.getStreetLines(

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
@@ -1210,22 +1210,30 @@ const highestZaehlwertRounded = computed(() => {
 
 const colorArrowOne = computed<string>(() => {
   if (!isSelectedArrowOne.value) return BelastungsplanConstants.inaktivColor;
-  return calculateColorArrowOneTwo();
+  return zaehlstelleStore.isBlackprintMode
+    ? "#000000"
+    : calculateColorArrowOneTwo();
 });
 
 const colorArrowTwo = computed<string>(() => {
   if (!isSelectedArrowTwo.value) return BelastungsplanConstants.inaktivColor;
-  return calculateColorArrowOneTwo();
+  return zaehlstelleStore.isBlackprintMode
+    ? "#000000"
+    : calculateColorArrowOneTwo();
 });
 
 const colorArrowThree = computed<string>(() => {
   if (!isSelectedArrowThree.value) return BelastungsplanConstants.inaktivColor;
-  return calculateColorArrowThreeFour();
+  return zaehlstelleStore.isBlackprintMode
+    ? "#000000"
+    : calculateColorArrowThreeFour();
 });
 
 const colorArrowFour = computed<string>(() => {
   if (!isSelectedArrowFour.value) return BelastungsplanConstants.inaktivColor;
-  return calculateColorArrowThreeFour();
+  return zaehlstelleStore.isBlackprintMode
+    ? "#000000"
+    : calculateColorArrowThreeFour();
 });
 
 function calculateColorArrowOneTwo() {

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanQjsSvg.vue
@@ -1211,28 +1211,28 @@ const highestZaehlwertRounded = computed(() => {
 const colorArrowOne = computed<string>(() => {
   if (!isSelectedArrowOne.value) return BelastungsplanConstants.inaktivColor;
   return zaehlstelleStore.isBlackprintMode
-    ? "#000000"
+    ? BelastungsplanConstants.blackPrintColor
     : calculateColorArrowOneTwo();
 });
 
 const colorArrowTwo = computed<string>(() => {
   if (!isSelectedArrowTwo.value) return BelastungsplanConstants.inaktivColor;
   return zaehlstelleStore.isBlackprintMode
-    ? "#000000"
+    ? BelastungsplanConstants.blackPrintColor
     : calculateColorArrowOneTwo();
 });
 
 const colorArrowThree = computed<string>(() => {
   if (!isSelectedArrowThree.value) return BelastungsplanConstants.inaktivColor;
   return zaehlstelleStore.isBlackprintMode
-    ? "#000000"
+    ? BelastungsplanConstants.blackPrintColor
     : calculateColorArrowThreeFour();
 });
 
 const colorArrowFour = computed<string>(() => {
   if (!isSelectedArrowFour.value) return BelastungsplanConstants.inaktivColor;
   return zaehlstelleStore.isBlackprintMode
-    ? "#000000"
+    ? BelastungsplanConstants.blackPrintColor
     : calculateColorArrowThreeFour();
 });
 

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanQuSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanQuSvg.vue
@@ -3819,6 +3819,7 @@ watch(
     () => props.data,
     () => optionen.value.chosenQuerungsverkehre,
     () => activeZaehlung.value.knotenarme,
+    () => zaehlstelleStore.isBlackprintMode,
   ],
   async () => {
     setStreetnameNodes();

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanQuSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanQuSvg.vue
@@ -3709,8 +3709,10 @@ function setColor(knNumber: number, direction: Himmelsrichtung) {
       knNumber,
       direction
     )
-      ? (BelastungsplanConstants.farben.get(knNumber) ??
-        BelastungsplanConstants.inaktivColor)
+      ? zaehlstelleStore.isBlackprintMode
+        ? "#000000"
+        : (BelastungsplanConstants.farben.get(knNumber) ??
+          BelastungsplanConstants.inaktivColor)
       : BelastungsplanConstants.inaktivColor
   );
 }

--- a/frontend/src/components/zaehlstelle/charts/BelastungsplanQuSvg.vue
+++ b/frontend/src/components/zaehlstelle/charts/BelastungsplanQuSvg.vue
@@ -3710,7 +3710,7 @@ function setColor(knNumber: number, direction: Himmelsrichtung) {
       direction
     )
       ? zaehlstelleStore.isBlackprintMode
-        ? "#000000"
+        ? BelastungsplanConstants.blackPrintColor
         : (BelastungsplanConstants.farben.get(knNumber) ??
           BelastungsplanConstants.inaktivColor)
       : BelastungsplanConstants.inaktivColor


### PR DESCRIPTION
# Description

Implements black print mode for zaehlarten QjS, FjS and Qu. Replaces static color `#000000` by constant `blackPrintColor`.

# Issue References

FV-584
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [x] Acceptance criteria are met
- [x] Testing is done (unit-tests, DEV-environment)
- [x] Build/Test workflow has successfully finished
- [x] Release notes are complemented
- [x] Documentation is complemented (operator manual, system specification, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved black-and-white print mode across load-plan charts.
  - Chart lines and directional arrows now consistently render in black when black-print mode is enabled.
  - Preserved existing colors and inactive-state styling during normal viewing and for unselected elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->